### PR TITLE
fix enter not moving cursor to start of line

### DIFF
--- a/src/view.v
+++ b/src/view.v
@@ -224,7 +224,8 @@ mut:
 
 struct Buffer {
 mut:
-	lines []string
+	lines   []string
+	history UndoRedoHistory
 }
 
 enum CmdCode as u8 {
@@ -1133,10 +1134,11 @@ fn (mut view View) enter() {
 
 	view.buffer.lines[y] = current_line[..x]
 	new_line := "${whitespace_prefix}${segment_after}"
-	defer { view.cursor.pos.x = new_line.len }
 	if y >= view.buffer.lines.len { view.buffer.lines << new_line } else {
 		view.buffer.lines.insert(y+1, new_line)
 	}
+
+	view.cursor.pos.x = 0
 }
 
 fn resolve_whitespace_prefix(line string) string {

--- a/src/view.v
+++ b/src/view.v
@@ -225,7 +225,6 @@ mut:
 struct Buffer {
 mut:
 	lines   []string
-	history UndoRedoHistory
 }
 
 enum CmdCode as u8 {
@@ -1138,7 +1137,7 @@ fn (mut view View) enter() {
 		view.buffer.lines.insert(y+1, new_line)
 	}
 
-	view.cursor.pos.x = 0
+	view.cursor.pos.x = whitespace_prefix.len
 }
 
 fn resolve_whitespace_prefix(line string) string {

--- a/src/view.v
+++ b/src/view.v
@@ -224,7 +224,7 @@ mut:
 
 struct Buffer {
 mut:
-	lines   []string
+	lines []string
 }
 
 enum CmdCode as u8 {

--- a/src/view_test.v
+++ b/src/view_test.v
@@ -142,6 +142,25 @@ fn test_v_toggles_visual_mode_and_starts_selection() {
 	assert fake_view.cursor.selection_start == Pos{ 6, 0 }
 }
 
+fn test_enter_moves_trailing_segment_to_next_line_and_moves_cursor_in_front() {
+	mut fake_view := View{ log: unsafe { nil }, mode: .insert }
+	// manually set the "document" contents
+	fake_view.buffer.lines = [
+		"1. first line with some trailing content"
+	]
+
+	fake_view.cursor.pos.x = 8
+	fake_view.cursor.pos.y = 0
+
+	fake_view.enter()
+
+	assert fake_view.buffer.lines == [
+		"1. first",
+		" line with some trailing content"
+	]
+	assert fake_view.cursor.pos.x == 0
+}
+
 fn test_enter_inserts_line_at_cur_pos_and_auto_indents() {
 	mut fake_view := View{ log: unsafe { nil }, mode: .insert }
 	// manually set the "document" contents

--- a/src/view_test.v
+++ b/src/view_test.v
@@ -161,6 +161,24 @@ fn test_enter_moves_trailing_segment_to_next_line_and_moves_cursor_in_front() {
 	assert fake_view.cursor.pos.x == 0
 }
 
+fn test_enter_moves_trailing_segment_to_next_line_and_moves_cursor_to_past_prefix_whitespace() {
+	mut fake_view := View{ log: unsafe { nil }, mode: .insert }
+	fake_view.buffer.lines = [
+		"    1. first line with whitespace prefix"
+	]
+
+	fake_view.cursor.pos.x = 10
+	fake_view.cursor.pos.y = 0
+
+	fake_view.enter()
+
+	assert fake_view.buffer.lines == [
+		"    1. fir",
+		"    st line with whitespace prefix"
+	]
+	assert fake_view.cursor.pos.x == 4
+}
+
 fn test_enter_inserts_line_at_cur_pos_and_auto_indents() {
 	mut fake_view := View{ log: unsafe { nil }, mode: .insert }
 	// manually set the "document" contents


### PR DESCRIPTION
Actually, I'm going to just force merge this. The tests show it's fixed, and the actual logic changes are minimal. Also I really need this to be part of master for now whilst I work on the diff logic...