### PR TITLE
fix: include status char separator

### DIFF
--- a/src/status_line.v
+++ b/src/status_line.v
@@ -43,7 +43,8 @@ fn draw_status_line(mut ctx tui.Context, status Status) {
 	paint_shape_text(mut ctx, ctx.window_width - 1, y, Color { 245, 42, 42 }, "${block}${block}")
 	ctx.bold()
 	paint_text_on_background(mut ctx, ctx.window_width - 1 - cursor_info_label.len, y, Color{ 245, 42, 42 }, Color{ 255, 255, 255 }, cursor_info_label)
-	paint_shape_text(mut ctx, ctx.window_width - 1 - cursor_info_label.len - 2, y, Color { 245, 42, 42 }, "${slant_left_flat_bottom}${block}")
+	paint_shape_text(mut ctx, ctx.window_width - 2 - cursor_info_label.len - 2, y, Color { 245, 42, 42 }, "${slant_right_flat_top}${slant_left_flat_bottom}${block}")
+	paint_shape_text(mut ctx, ctx.window_width - 2 - cursor_info_label.len - 2, y, Color { 25, 25, 25 }, "${slant_right_flat_top}")
 }
 
 fn draw_file_name_segment(mut ctx tui.Context, x int, y int, file_name string) int {


### PR DESCRIPTION
The status line does not have a nice separator char between the base dark bar and red cursor info segment