### PR TITLE
Bugfix/clear d count on escape

### DIFF
--- a/src/mode.v
+++ b/src/mode.v
@@ -22,6 +22,7 @@ enum Mode as u8 {
 	insert
 	command
 	search
+	pending_delete
 }
 
 fn (mode Mode) draw(mut ctx tui.Context, x int, y int) int {
@@ -46,6 +47,7 @@ fn (mode Mode) color() Color {
 		.insert { status_orange }
 		.command { status_cyan }
 		.search { status_purple }
+		.pending_delete { status_green }
 	}
 }
 
@@ -56,6 +58,7 @@ fn (mode Mode) str() string {
 		.insert  { "INSERT"  }
 		.command { "COMMAND" }
 		.search  { "SEARCH"  }
+		.pending_delete { "NORMAL" }
 	}
 }
 

--- a/src/view.v
+++ b/src/view.v
@@ -862,6 +862,13 @@ fn (mut view View) on_key_down(e &tui.Event) {
 				}
 			}
 		}
+		.pending_delete {
+			match e.code {
+				.escape { view.escape() }
+				.d { view.d() }
+				else {}
+			}
+		}
 	}
 }
 
@@ -1112,6 +1119,7 @@ fn (mut view View) dollar() {
 
 fn (mut view View) d() {
 	view.d_count += 1
+	if view.d_count == 1 { view.mode = .pending_delete }
 	if view.d_count == 2 {
 		index := if view.cursor.pos.y == view.buffer.lines.len { view.cursor.pos.y - 1 } else { view.cursor.pos.y }
 		view.y_lines = []string{}
@@ -1119,6 +1127,7 @@ fn (mut view View) d() {
 		view.buffer.lines.delete(index)
 		view.d_count = 0
 		view.clamp_cursor_within_document_bounds()
+		view.mode = .normal
 	}
 }
 

--- a/src/view.v
+++ b/src/view.v
@@ -923,6 +923,7 @@ fn (mut view View) escape() {
 	view.clamp_cursor_x_pos()
 	view.cmd_buf.clear()
 	view.search.clear()
+	view.d_count = 0
 
 	// if current line only contains whitespace prefix clear the line
 	line := view.buffer.lines[view.cursor.pos.y]


### PR DESCRIPTION
For the recently added cursor visual change for during a "pending line deletion", this highlighted that it was possible to do heinous things like move the cursor during this state, so now we explicitly state what input is allowed during the pending delete state. Visually this should be hidden from the user.