### PR TITLE
Feat/define custom clipboard lib with interface type

### DIFF
--- a/src/lib/clipboard/clipboard.v
+++ b/src/lib/clipboard/clipboard.v
@@ -3,7 +3,7 @@ module clipboard
 pub interface Clipboard {
 mut:
 	copy(text string) bool
-	paste() string
+	paste() []string
 }
 
 pub fn new() Clipboard {

--- a/src/lib/clipboard/clipboard.v
+++ b/src/lib/clipboard/clipboard.v
@@ -1,0 +1,12 @@
+module clipboard
+
+pub interface Clipboard {
+mut:
+	copy(text string) bool
+	paste() string
+}
+
+pub fn new() Clipboard {
+	return new_clipboard()
+}
+

--- a/src/lib/clipboard/clipboard_test.v
+++ b/src/lib/clipboard/clipboard_test.v
@@ -1,8 +1,0 @@
-module clipboard
-
-fn test_clipboard_copy() {
-	mut clip := new()
-	assert clip.copy("some text")
-	assert clip.paste() == ["some text"]
-}
-

--- a/src/lib/clipboard/clipboard_test.v
+++ b/src/lib/clipboard/clipboard_test.v
@@ -1,0 +1,8 @@
+module clipboard
+
+fn test_clipboard_copy() {
+	mut clip := new()
+	assert clip.copy("some text")
+	assert clip.paste() == ["some text"]
+}
+

--- a/src/lib/clipboard/mock_clipboard.v
+++ b/src/lib/clipboard/mock_clipboard.v
@@ -1,0 +1,18 @@
+module clipboard
+
+[heap]
+struct MockClipboard {
+mut:
+	copied_content      string
+	was_copy_unsuccessful bool
+}
+
+fn (mut mockclipboard MockClipboard) copy(text string) bool {
+	mockclipboard.copied_content = text
+	return !mockclipboard.was_copy_unsuccessful
+}
+
+fn (mut mockclipboard MockClipboard) paste() []string {
+	return mockclipboard.copied_content.split_into_lines()
+}
+

--- a/src/lib/clipboard/xclip_backend_default.v
+++ b/src/lib/clipboard/xclip_backend_default.v
@@ -1,0 +1,1 @@
+module clipboard

--- a/src/lib/clipboard/xclip_backend_linux.v
+++ b/src/lib/clipboard/xclip_backend_linux.v
@@ -28,7 +28,7 @@ fn (xclipboard XClipClipboard) paste() []string {
 	defer { cmd.close() or { } }
 	cmd.start() or { panic(err) }
 
-	mut out := []string
+	mut out := []string{}
 	for {
 		out << cmd.read_line()
 		if cmd.eof { break }

--- a/src/lib/clipboard/xclip_backend_linux.v
+++ b/src/lib/clipboard/xclip_backend_linux.v
@@ -8,7 +8,10 @@ mut:
 	content string
 }
 
-fn new_clipboard() &XClipClipboard {
+fn new_clipboard() Clipboard {
+	$if test {
+		return &MockClipboard{}
+	}
 	return &XClipClipboard{}
 }
 

--- a/src/lib/clipboard/xclip_backend_linux.v
+++ b/src/lib/clipboard/xclip_backend_linux.v
@@ -1,5 +1,7 @@
 module clipboard
 
+import os
+
 [heap]
 struct XClipClipboard {
 mut:
@@ -10,6 +12,29 @@ fn new_clipboard() &XClipClipboard {
 	return &XClipClipboard{}
 }
 
-fn (mut xclipboard XClipClipboard) copy(text string) bool { xclipboard.content = text; return true }
+fn (mut xclipboard XClipClipboard) copy(text string) bool {
+	xclipboard.content = text
+	mut cmd := os.Command{
+		path: "echo ${text} | xclip -i"
+	}
+	cmd.start() or { return false }
+	return cmd.exit_code == 0
+}
 
-fn (xclipboard XClipClipboard) paste() string { return xclipboard.content }
+fn (xclipboard XClipClipboard) paste() string {
+	mut cmd := os.Command{
+		path: "xclip -o"
+	}
+	cmd.start() or { panic(err) }
+
+	mut out := ""
+	for {
+		out += cmd.read_line()
+		if cmd.eof { break }
+	}
+
+	if cmd.exit_code == 0 { return out }
+
+	return ""
+}
+

--- a/src/lib/clipboard/xclip_backend_linux.v
+++ b/src/lib/clipboard/xclip_backend_linux.v
@@ -13,28 +13,29 @@ fn new_clipboard() &XClipClipboard {
 }
 
 fn (mut xclipboard XClipClipboard) copy(text string) bool {
-	xclipboard.content = text
 	mut cmd := os.Command{
-		path: "echo ${text} | xclip -i"
+		path: "echo '${text}' | xclip -i -r"
 	}
+	defer { cmd.close() or { } }
 	cmd.start() or { return false }
 	return cmd.exit_code == 0
 }
 
-fn (xclipboard XClipClipboard) paste() string {
+fn (xclipboard XClipClipboard) paste() []string {
 	mut cmd := os.Command{
 		path: "xclip -o"
 	}
+	defer { cmd.close() or { } }
 	cmd.start() or { panic(err) }
 
-	mut out := ""
+	mut out := []string
 	for {
-		out += cmd.read_line()
+		out << cmd.read_line()
 		if cmd.eof { break }
 	}
 
 	if cmd.exit_code == 0 { return out }
 
-	return ""
+	return []
 }
 

--- a/src/lib/clipboard/xclip_backend_linux.v
+++ b/src/lib/clipboard/xclip_backend_linux.v
@@ -1,0 +1,15 @@
+module clipboard
+
+[heap]
+struct XClipClipboard {
+mut:
+	content string
+}
+
+fn new_clipboard() &XClipClipboard {
+	return &XClipClipboard{}
+}
+
+fn (mut xclipboard XClipClipboard) copy(text string) bool { xclipboard.content = text; return true }
+
+fn (xclipboard XClipClipboard) paste() string { return xclipboard.content }

--- a/src/main.v
+++ b/src/main.v
@@ -17,6 +17,7 @@ module main
 import os
 import term.ui as tui
 import log
+import lib.clipboard
 
 struct App {
 mut:
@@ -97,7 +98,9 @@ fn main() {
 		capture_events: true
 		use_alternate_buffer: true
     )
-	app.views << app.new_view()
+
+	clip := clipboard.new()
+	app.views << app.new_view(clip)
 	app.update_view()
 
 	path := os.args[1] or { panic("missing file path") }

--- a/src/view.v
+++ b/src/view.v
@@ -21,6 +21,7 @@ import datatypes
 import strconv
 import regex
 import lib.clipboard
+import arrays
 
 struct Cursor {
 mut:
@@ -117,7 +118,6 @@ mut:
 	current_syntax_idx        int
 	is_multiline_comment      bool
 	d_count                   int
-	y_lines                   []string
 	clipboard                 clipboard.Clipboard
 }
 
@@ -1083,13 +1083,19 @@ fn (mut view View) v() {
 }
 
 fn (mut view View) visual_y() {
-	mut y_lines := []string{}
 	start := view.cursor.selection_start_y()
 	mut end   := view.cursor.selection_end_y()
 	if end+1 >= view.buffer.lines.len { end = view.buffer.lines.len-1 }
-	y_lines = view.buffer.lines[start..end+1]
-	view.y_lines = y_lines.clone()
+	view.copy_lines_into_clipboard(start, end)
 	view.escape()
+}
+
+fn (mut view View) copy_lines_into_clipboard(start int, end int) {
+	view.clipboard.copy(arrays.join_to_string(view.buffer.lines[start..end+1].clone(), "\n", fn (s string) string { return s }))
+}
+
+fn (mut view View) read_lines_from_clipboard() []string {
+	return view.clipboard.paste().split_into_lines()
 }
 
 fn (mut view View) visual_d(overwrite_y_lines bool) {
@@ -1097,7 +1103,7 @@ fn (mut view View) visual_d(overwrite_y_lines bool) {
 	mut start := view.cursor.selection_start_y()
 	mut end := view.cursor.selection_end_y()
 
-	view.y_lines = view.buffer.lines[start..end+1]
+	view.copy_lines_into_clipboard(start, end)
 	before := view.buffer.lines[..start]
 	after := view.buffer.lines[end+1..]
 
@@ -1161,8 +1167,7 @@ fn (mut view View) d() {
 	if view.d_count == 1 { view.mode = .pending_delete }
 	if view.d_count == 2 {
 		index := if view.cursor.pos.y == view.buffer.lines.len { view.cursor.pos.y - 1 } else { view.cursor.pos.y }
-		view.y_lines = []string{}
-		view.y_lines << view.buffer.lines[index]
+		view.copy_lines_into_clipboard(index, index - 1)
 		view.buffer.lines.delete(index)
 		view.d_count = 0
 		view.clamp_cursor_within_document_bounds()
@@ -1181,8 +1186,9 @@ fn (mut view View) o() {
 }
 
 fn (mut view View) p() {
-	view.buffer.lines.insert(view.cursor.pos.y+1, view.y_lines)
-	view.move_cursor_down(view.y_lines.len)
+	copied_lines := view.read_lines_from_clipboard()
+	view.buffer.lines.insert(view.cursor.pos.y+1, copied_lines)
+	view.move_cursor_down(copied_lines.len)
 }
 
 fn (mut view View) visual_p() {
@@ -1193,11 +1199,13 @@ fn (mut view View) visual_p() {
 	before := view.buffer.lines[..start]
 	after := view.buffer.lines[end+1..]
 
+	copied_lines := view.read_lines_from_clipboard()
+
 	view.buffer.lines = before
 	view.buffer.lines << after
 	view.cursor.pos.y = start
-	view.buffer.lines.insert(view.cursor.pos.y, view.y_lines)
-	view.move_cursor_down(view.y_lines.len)
+	view.buffer.lines.insert(view.cursor.pos.y, copied_lines)
+	view.move_cursor_down(copied_lines.len)
 	view.escape()
 }
 

--- a/src/view.v
+++ b/src/view.v
@@ -20,6 +20,7 @@ import log
 import datatypes
 import strconv
 import regex
+import lib.clipboard
 
 struct Cursor {
 mut:
@@ -117,6 +118,7 @@ mut:
 	is_multiline_comment      bool
 	d_count                   int
 	y_lines                   []string
+	clipboard                 clipboard.Clipboard
 }
 
 struct FindCursor {
@@ -397,8 +399,8 @@ fn (mut cmd_buf CmdBuffer) clear_err() {
 	cmd_buf.code = .blank
 }
 
-fn (app &App) new_view() View {
-	mut res := View{ log: app.log, mode: .normal, show_whitespace: false }
+fn (app &App) new_view(_clipboard clipboard.Clipboard) View {
+	mut res := View{ log: app.log, mode: .normal, show_whitespace: false, clipboard: _clipboard }
 	res.load_syntaxes()
 	res.load_config()
 	res.set_current_syntax_idx(".v")

--- a/src/view.v
+++ b/src/view.v
@@ -1095,7 +1095,7 @@ fn (mut view View) copy_lines_into_clipboard(start int, end int) {
 }
 
 fn (mut view View) read_lines_from_clipboard() []string {
-	return view.clipboard.paste().split_into_lines()
+	return view.clipboard.paste()
 }
 
 fn (mut view View) visual_d(overwrite_y_lines bool) {
@@ -1167,7 +1167,7 @@ fn (mut view View) d() {
 	if view.d_count == 1 { view.mode = .pending_delete }
 	if view.d_count == 2 {
 		index := if view.cursor.pos.y == view.buffer.lines.len { view.cursor.pos.y - 1 } else { view.cursor.pos.y }
-		view.copy_lines_into_clipboard(index, index - 1)
+		view.copy_lines_into_clipboard(index, index)
 		view.buffer.lines.delete(index)
 		view.d_count = 0
 		view.clamp_cursor_within_document_bounds()

--- a/src/view_test.v
+++ b/src/view_test.v
@@ -437,8 +437,6 @@ fn test_visual_selection_copy() {
 		"5. fifth line"
 	]
 
-	assert fake_view.read_lines_from_clipboard() == []
-
 	// ensure cursor is set to sit on second line
 	fake_view.cursor.pos.x = 0
 	fake_view.cursor.pos.y = 1

--- a/src/view_test.v
+++ b/src/view_test.v
@@ -14,8 +14,12 @@
 
 module main
 
+import lib.clipboard
+import arrays
+
 fn test_dd_deletes_current_line_at_start_of_doc() {
-	mut fake_view := View{ log: unsafe { nil }, mode: .normal }
+	mut clip := clipboard.new()
+	mut fake_view := View{ log: unsafe { nil }, mode: .normal, clipboard: mut clip }
 	fake_view.buffer.lines = ["1. first line", "2. second line", "3. third line", "4. forth line"]
 	fake_view.cursor.pos.y = 0
 
@@ -23,11 +27,12 @@ fn test_dd_deletes_current_line_at_start_of_doc() {
 	fake_view.d()
 
 	assert fake_view.buffer.lines == ["2. second line", "3. third line", "4. forth line"]
-	assert fake_view.y_lines == ["1. first line"]
+	assert fake_view.read_lines_from_clipboard() == ["1. first line"]
 }
 
 fn test_dd_deletes_current_line_in_middle_of_doc() {
-	mut fake_view := View{ log: unsafe { nil }, mode: .normal }
+	mut clip := clipboard.new()
+	mut fake_view := View{ log: unsafe { nil }, mode: .normal, clipboard: mut clip }
 	fake_view.buffer.lines = ["1. first line", "2. second line", "3. third line", "4. forth line"]
 	fake_view.cursor.pos.y = 2
 
@@ -36,11 +41,12 @@ fn test_dd_deletes_current_line_in_middle_of_doc() {
 
 	assert fake_view.buffer.lines == ["1. first line", "2. second line", "4. forth line"]
 	assert fake_view.cursor.pos.y == 2
-	assert fake_view.y_lines == ["3. third line"]
+	assert fake_view.read_lines_from_clipboard() == ["3. third line"]
 }
 
 fn test_dd_deletes_current_line_at_end_of_doc() {
-	mut fake_view := View{ log: unsafe { nil }, mode: .normal }
+	mut clip := clipboard.new()
+	mut fake_view := View{ log: unsafe { nil }, mode: .normal, clipboard: mut clip }
 	// manually set the "document" contents
 	fake_view.buffer.lines = ["1. first line", "2. second line", "3. third line"]
 	// ensure the cursor is set to sit on the last line
@@ -52,7 +58,7 @@ fn test_dd_deletes_current_line_at_end_of_doc() {
 
 	assert fake_view.buffer.lines == ["1. first line", "2. second line"]
 	assert fake_view.cursor.pos.y == 1
-	assert fake_view.y_lines == ["3. third line"]
+	assert fake_view.read_lines_from_clipboard() == ["3. third line"]
 }
 
 fn test_o_inserts_sentance_line() {
@@ -384,7 +390,8 @@ fn test_right_arrow_at_end_of_sentence_in_insert_mode() {
 }
 
 fn test_visual_insert_mode_and_delete_in_place() {
-	mut fake_view := View{ log: unsafe{ nil }, mode: .normal }
+	mut clip := clipboard.new()
+	mut fake_view := View{ log: unsafe{ nil }, mode: .normal, clipboard: mut clip }
 
 	// manually set the documents contents
 	fake_view.buffer.lines = ["1. first line", "2. second line", "3. third line", "4. forth line"]
@@ -400,7 +407,8 @@ fn test_visual_insert_mode_and_delete_in_place() {
 }
 
 fn test_visual_insert_mode_selection_move_down_once_and_delete() {
-	mut fake_view := View{ log: unsafe { nil }, mode: .normal }
+	mut clip := clipboard.new()
+	mut fake_view := View{ log: unsafe { nil }, mode: .normal, clipboard: mut clip }
 
 	// manually set the documents contents
 	fake_view.buffer.lines = ["1. first line", "2. second line", "3. third line", "4. forth line"]
@@ -417,7 +425,8 @@ fn test_visual_insert_mode_selection_move_down_once_and_delete() {
 }
 
 fn test_visual_selection_copy() {
-	mut fake_view := View{ log: unsafe { nil }, mode: .normal }
+	mut clip := clipboard.new()
+	mut fake_view := View{ log: unsafe { nil }, mode: .normal, clipboard: mut clip }
 
 	// manually set the documents contents
 	fake_view.buffer.lines = [
@@ -428,7 +437,7 @@ fn test_visual_selection_copy() {
 		"5. fifth line"
 	]
 
-	assert fake_view.y_lines == []
+	assert fake_view.read_lines_from_clipboard() == []
 
 	// ensure cursor is set to sit on second line
 	fake_view.cursor.pos.x = 0
@@ -438,14 +447,20 @@ fn test_visual_selection_copy() {
 	fake_view.j()
 	fake_view.visual_y()
 
-	assert fake_view.y_lines == [
+	assert fake_view.read_lines_from_clipboard() == [
 		"2. second line",
 		"3. third line"
 	]
 }
 
 fn test_paste() {
-	mut fake_view := View{ log: unsafe { nil }, mode: .normal }
+	mut clip := clipboard.new()
+	clip.copy(arrays.join_to_string(
+	    ["some new random contents", "with multiple lines"],
+		"\n",
+		fn (s string) string { return s }
+	))
+	mut fake_view := View{ log: unsafe { nil }, mode: .normal, clipboard: mut clip }
 
 	// manually set the documents contents
 	fake_view.buffer.lines = [
@@ -455,8 +470,6 @@ fn test_paste() {
 		"4. forth line",
 		"5. fifth line"
 	]
-
-	fake_view.y_lines = ["some new random contents", "with multiple lines"]
 
 	// ensure cursor is set to sit on second line
 	fake_view.cursor.pos.x = 0
@@ -476,7 +489,13 @@ fn test_paste() {
 }
 
 fn test_visual_paste() {
-	mut fake_view := View{ log: unsafe { nil }, mode: .normal }
+	mut clip := clipboard.new()
+	clip.copy(arrays.join_to_string(
+	    ["some new random contents", "with multiple lines"],
+		"\n",
+		fn (s string) string { return s }
+	))
+	mut fake_view := View{ log: unsafe { nil }, mode: .normal, clipboard: mut clip }
 
 	// manually set the documents contents
 	fake_view.buffer.lines = [
@@ -486,8 +505,6 @@ fn test_visual_paste() {
 		"4. forth line",
 		"5. fifth line"
 	]
-
-	fake_view.y_lines = ["some new random contents", "with multiple lines"]
 
 	// ensure cursor is set to sit on second line
 	fake_view.cursor.pos.x = 0
@@ -596,7 +613,7 @@ fn test_search_within_for_multiple_lines_multiple_matches_per_line() {
 }
 
 fn test_move_cursor_with_b_from_start_of_line_which_preceeds_a_blank_line() {
-	mut fake_view := View{ log: unsafe { nil }, mode: .normal }
+	mut fake_view := View{ log: unsafe { nil }, mode: .normal, clipboard: clipboard.new() }
 	fake_view.buffer.lines = ["1. first line", "", "3. third line"]
 
 	fake_view.cursor.pos.x = 0
@@ -609,7 +626,7 @@ fn test_move_cursor_with_b_from_start_of_line_which_preceeds_a_blank_line() {
 }
 
 fn test_jump_cursor_up_to_next_blank_line() {
-	mut fake_view := View{ log: unsafe { nil }, mode: .normal }
+	mut fake_view := View{ log: unsafe { nil }, mode: .normal, clipboard: clipboard.new() }
 	fake_view.buffer.lines = [
 		"# Top of the file"
 		"",
@@ -629,7 +646,7 @@ fn test_jump_cursor_up_to_next_blank_line() {
 }
 
 fn test_jump_cursor_down_to_next_blank_line() {
-	mut fake_view := View{ log: unsafe { nil }, mode: .normal }
+	mut fake_view := View{ log: unsafe { nil }, mode: .normal, clipboard: clipboard.new() }
 	fake_view.buffer.lines = [
 		"# Top of the file"
 		"",


### PR DESCRIPTION
So... on Linux Lilly will now overwrite and read from the system clipboard. For now Lilly will just fail to compile on any non-Linux OS 😅 I'll amend this in the next PR.