### PR TITLE
Fix/remove compiler warnings

### DIFF
--- a/src/lib/buffer/buffer.v
+++ b/src/lib/buffer/buffer.v
@@ -1,7 +1,6 @@
 module buffer
 
 import history { History }
-import lib.diff { Op }
 import os
 
 pub struct Buffer {

--- a/src/lib/clipboard/mock_clipboard.v
+++ b/src/lib/clipboard/mock_clipboard.v
@@ -1,6 +1,6 @@
 module clipboard
 
-[heap]
+@[heap]
 struct MockClipboard {
 mut:
 	copied_content      string

--- a/src/lib/clipboard/stdlib_backend.v
+++ b/src/lib/clipboard/stdlib_backend.v
@@ -2,7 +2,7 @@ module clipboard
 
 import clipboard as stdlib_clipboard
 
-[heap]
+@[heap]
 struct StdLibClipboard {
 mut:
 	ref &stdlib_clipboard.Clipboard

--- a/src/lib/clipboard/wayland_backend.v
+++ b/src/lib/clipboard/wayland_backend.v
@@ -2,7 +2,7 @@ module clipboard
 
 import os
 
-[heap]
+@[heap]
 struct WaylandClipboard {}
 
 fn (mut wclipboard WaylandClipboard) copy(text string) bool {

--- a/src/lib/clipboard/xclip_backend.v
+++ b/src/lib/clipboard/xclip_backend.v
@@ -2,7 +2,7 @@ module clipboard
 
 import os
 
-[heap]
+@[heap]
 struct XClipClipboard {}
 
 fn (mut xclipboard XClipClipboard) copy(text string) bool {

--- a/src/main.v
+++ b/src/main.v
@@ -65,7 +65,7 @@ fn frame(mut app &App) {
 	}
 }
 
-[console]
+@[console]
 fn main() {
 	mut l := log.Log{}
 	l.set_level(.debug)


### PR DESCRIPTION
NOTE: This PR relates to using V version: V 0.4.3 782bf86 or above. I.e, it'll be a requirement once this PR is merged for us to all be on at least this compiler version, as otherwise you will not be able to compile.