### PR TITLE
fix: when cropping visual length of lines don't incorrectly strip UTF…

### DIFF
--- a/src/view.v
+++ b/src/view.v
@@ -571,7 +571,7 @@ fn (mut view View) draw_text_line(mut ctx tui.Context, y int, line string, withi
 	visible_len := utf8_str_visible_length(linex)
 	if max_width > visible_len { max_width = visible_len }
 
-	linex = linex[..max_width]
+	linex = linex.runes()[..max_width].string()
 
 	segments, is_multiline_comment := resolve_line_segments(view.syntaxes[view.current_syntax_idx] or { workspace.Syntax{} }, linex, view.is_multiline_comment)
 	view.is_multiline_comment = is_multiline_comment


### PR DESCRIPTION
…-8 code points

This PR fixes us not rendering Unicode chars at the end of lines correctly. This is the first step to fixing the renderer to correctly handle UTF-8.

![Screenshot 2023-11-30 11 42 15](https://github.com/tauraamui/lilly/assets/3159648/26a3c372-c94f-4072-88a3-58ae5c7eb2d6)
