### PR TITLE
fix/prevent backspace stripping utf-8 code points on backspace

### DIFF
--- a/src/view.v
+++ b/src/view.v
@@ -1417,13 +1417,13 @@ fn (mut view View) backspace() {
 	}
 
 	if view.cursor.pos.x == line.len {
-		view.buffer.lines[y] = line[..line.len - 1]
+		view.buffer.lines[y] = line.runes()[..line.len - 1].string()
 		view.cursor.pos.x = view.buffer.lines[y].len
 		return
 	}
 
-	before := line[..view.cursor.pos.x-1]
-	after := line[view.cursor.pos.x..]
+	before := line.runes()[..view.cursor.pos.x-1].string()
+	after := line.runes()[view.cursor.pos.x..].string()
 	view.buffer.lines[y] = "${before}${after}"
 	view.cursor.pos.x -= 1
 	if view.cursor.pos.x < 0 { view.cursor.pos.x = 0 }

--- a/src/view.v
+++ b/src/view.v
@@ -593,7 +593,7 @@ fn (mut view View) draw_text_line(mut ctx tui.Context, y int, line string, withi
 	for i, segment in segments {
 		// render text before next segment
 		if segment.start > pos {
-			s := linex[pos..segment.start]
+			s := linex.runes()[pos..segment.start].string()
 			ctx.draw_text(view.x+1+pos, y+1, s)
 		}
 
@@ -604,13 +604,13 @@ fn (mut view View) draw_text_line(mut ctx tui.Context, y int, line string, withi
 			.a_string { Color{ 87, 215, 217 } }
 			.a_comment { Color{ 130, 130, 130 } }
 		}
-		s := linex[segment.start..segment.end]
+		s := linex.runes()[segment.start..segment.end].string()
 		ctx.set_color(r: color.r, g: color.g, b: color.b)
 		ctx.draw_text(view.x+1+segment.start, y+1, s)
 		ctx.reset_color()
 		pos = segment.end
 		if i == segments.len - 1 && segment.end < linex.len {
-			final := linex[segment.end..linex.len]
+			final := linex.runes()[segment.end..linex.runes().len].string()
 			ctx.draw_text(view.x+1+pos, y+1, final)
 		}
 	}
@@ -639,7 +639,7 @@ fn resolve_line_segments(syntax workspace.Syntax, line string, is_multiline_comm
 		if i > 0 && line_runes[i - 1] == `/` && line_runes[i] == `*` && !(line_runes[line_runes.len - 2] == `*`
 			&& line_runes[line_runes.len - 1] == `/`) {
 			// all after /* is  a comment
-			segments << LineSegment{ start, line.len, .a_comment }
+			segments << LineSegment{ start, line_runes.len, .a_comment }
 			is_multiline_commentx = true
 			break
 		}
@@ -689,7 +689,7 @@ fn resolve_line_segments(syntax workspace.Syntax, line string, is_multiline_comm
 		for i < line.len && is_alpha_underscore(int(line[i])) {
 			i++
 		}
-		word := line[start..i]
+		word := line.runes()[start..i].string()
 		if word in syntax.literals {
 			segments << LineSegment{ start, i, .a_lit }
 		} else if word in syntax.keywords {


### PR DESCRIPTION
This PR fixes our incorrect rendering of lines with UTF-8, although interestingly whilst creating this video I discovered another apparent fatal crash bug that'll be a separate investigation and fix.

[Screen recording 2023-11-30 12.17.52.webm](https://github.com/tauraamui/lilly/assets/3159648/1d05a17e-40b5-4ad5-a39a-e782adc15bb2)
