### PR TITLE
remove ability to invoke keys with ctrl in insert mode

### DIFF
--- a/src/view.v
+++ b/src/view.v
@@ -944,6 +944,7 @@ fn (mut view View) on_key_down(e &tui.Event, mut root Root) {
 			}
 		}
 		.insert {
+			if e.modifiers == .ctrl { return }
 			match e.code {
 				// ignored/currently "handled" but rejected keys
 				.f1 { }


### PR DESCRIPTION
Basically, if you press, `Ctrl + <some other key>`, this normally results in some form of heinous whitespace unicode code points being inserted into the document, which is unlikely what the user wanted.