### PR TITLE
switch to using tee to output and store current hash

### DIFF
--- a/justfile
+++ b/justfile
@@ -26,7 +26,7 @@ compile-gui: generate-git-hash
     v -d gui ./src -o lillygui
 
 generate-git-hash:
-    git log -n 1 --pretty=format:"%h" > ./src/.githash
+    git log -n 1 --pretty=format:"%h" | tee ./src/.githash
 
 build: prod-compile
 


### PR DESCRIPTION
Before this change, it's actually slightly annoying in that I still have to manually ensure/check that I am _definitely_ running the currently latest built version by comparing the splash screen hash with the actual latest git commit hash.