### PR TITLE
Add '0' key behavior in .normal mode and fix '^' behavior

### DIFF
--- a/src/view.v
+++ b/src/view.v
@@ -1719,6 +1719,23 @@ fn (mut view View) ctrl_u() {
 }
 
 fn (mut view View) hat() {
+	defer { view.clamp_cursor_x_pos() }
+	line := view.buffer.lines[view.cursor.pos.y]
+	if line.len == 0 { return }
+
+	mut pos := 0
+	line_chars := line.runes()
+	for is_whitespace(line_chars[pos]) {
+		pos += 1
+		if !is_whitespace(line_chars[pos]) {
+			view.cursor.pos.x = pos
+			return
+		}
+	}
+	view.cursor.pos.x = pos
+}
+
+fn (mut view View) zero() {
 	view.cursor.pos.x = 0
 }
 

--- a/src/view_keybinds.v
+++ b/src/view_keybinds.v
@@ -142,7 +142,10 @@ fn (mut view View) on_key_down(e draw.Event, mut root Root) {
 				.slash {
 					view.search()
 				}
-				48...57 { // 0-9a
+				48...48 {
+					view.zero()	
+				}
+				49...57 { // 0-9a
 					view.chord.append_to_repeat_amount(e.ascii.ascii_str())
 				}
 				else {}

--- a/src/view_test.v
+++ b/src/view_test.v
@@ -2498,3 +2498,34 @@ fn test_search_line_correct_overwrite() {
 	assert fake_view.search.to_find == '/'
 	assert fake_view.search.cursor_x == 1
 }
+
+fn test_zero_key_handling() {
+	mut clip := clipboard.new()
+	mut fake_view := View{
+		log: unsafe { nil }
+		leader_state: ViewLeaderState{ mode: .normal }
+		clipboard: mut clip
+	}
+
+	fake_view.buffer.lines = ['    This is a test line', 'Another line']
+
+	// Set cursor to middle of first line
+	fake_view.cursor.pos.x = 10
+	fake_view.cursor.pos.y = 0
+
+	// Simulate '0' key press
+	fake_view.zero()
+	
+	// Verify cursor moved to start of line
+	assert fake_view.cursor.pos.x == 0
+	assert fake_view.cursor.pos.y == 0
+
+	// Test that other number keys still append to chord repeat amount
+	fake_view.chord.append_to_repeat_amount('5')
+	assert fake_view.chord.pending_repeat_amount() == '5'
+
+	// Ensure '0' doesn't append to repeat amount when it's the first number
+	fake_view.chord.reset()
+	fake_view.zero()
+	assert fake_view.chord.pending_repeat_amount() == ''
+}


### PR DESCRIPTION
I added the same behavior for the '0' key, in normal mode, that vim/nvim appear to have (the docs for vim also appear to indicate this behavior is the correct way to do things).

Since the '0' behavior is 'correct' with this PR, then the '^' behavior could also be updated to act the same as vim/nvim. (ie. the '^' takes one to the first non-whitespace character at the beginning of the line...not the '0'th character).

I am not totally sure if this is what you want, but I use '0' and '^' a lot, and it was very strange for these keys to not work the same with lilly as in vim/nvim.