### PR TITLE
Add the zz action for centering text vertially

### DIFF
--- a/src/mode.v
+++ b/src/mode.v
@@ -26,6 +26,7 @@ enum Mode as u8 {
 	leader
 	pending_delete
 	replace
+	pending_z
 }
 
 fn (mode Mode) draw(mut ctx draw.Contextable, x int, y int) int {
@@ -56,6 +57,7 @@ fn (mode Mode) color() Color {
 		.leader { status_purple }
 		.pending_delete { status_green }
 		.replace { status_green }
+		.pending_z { status_green }
 	}
 }
 
@@ -70,5 +72,6 @@ fn (mode Mode) str() string {
 		.leader { 'LEADER' }
 		.pending_delete { 'NORMAL' }
 		.replace { 'NORMAL' }
+		.pending_z { "NORMAL" }
 	}
 }

--- a/src/view.v
+++ b/src/view.v
@@ -1750,11 +1750,11 @@ fn (mut view View) d() {
 
 fn (mut view View) z() {
 	view.z_count += 1
-	if view.z_count == 1 { view.mode = .pending_z }
+	if view.z_count == 1 { view.leader_state.mode = .pending_z }
 	if view.z_count == 2 {
 		view.center_text_around_cursor()
 		view.z_count = 0
-		view.mode = .normal
+		view.leader_state.mode = .normal
 	}
 }
 

--- a/src/view_keybinds.v
+++ b/src/view_keybinds.v
@@ -104,6 +104,7 @@ fn (mut view View) on_key_down(e draw.Event, mut root Root) {
 				.c {
 					view.exec(view.chord.c())
 				}
+				.z     { view.z() }
 				.d {
 					if e.modifiers == .ctrl {
 						view.ctrl_d()
@@ -453,6 +454,13 @@ fn (mut view View) on_key_down(e draw.Event, mut root Root) {
 			match e.code {
 				.escape { view.escape() }
 				.d { view.d() }
+				else {}
+			}
+		}
+		.pending_z {
+			match e.code {
+				.escape { view.escape() }
+				.z { view.z() }
 				else {}
 			}
 		}

--- a/src/view_test.v
+++ b/src/view_test.v
@@ -2498,3 +2498,55 @@ fn test_search_line_correct_overwrite() {
 	assert fake_view.search.to_find == '/'
 	assert fake_view.search.cursor_x == 1
 }
+
+fn test_center_text_around_cursor() {
+    mut clip := clipboard.new()
+    mut fake_view := View{
+        log: unsafe { nil }
+        leader_state: ViewLeaderState{ mode: .normal }
+        clipboard: mut clip
+        height: 10 // Set a small height for testing
+    }
+
+    // Create a document with more lines than the view height
+    fake_view.buffer.lines = [
+        'Line 1', 'Line 2', 'Line 3', 'Line 4', 'Line 5',
+        'Line 6', 'Line 7', 'Line 8', 'Line 9', 'Line 10',
+        'Line 11', 'Line 12', 'Line 13', 'Line 14', 'Line 15'
+    ]
+
+    // Set initial view bounds
+    fake_view.from = 0
+    fake_view.to = 10
+
+    // Set cursor to Line 8
+    fake_view.cursor.pos.y = 7
+    mut original_cursor_pos := fake_view.cursor.pos.y
+
+    // Call the center_text_around_cursor function
+    fake_view.center_text_around_cursor()
+
+    // Check if the cursor position remains unchanged
+    assert fake_view.cursor.pos.y == original_cursor_pos
+
+    // Check if the view is centered correctly
+	// The '+2' is to account for the extra lines in the total
+	// height of the view, used so we don't run off the bottom
+	// of the view
+    assert fake_view.from <= original_cursor_pos
+    assert fake_view.to > original_cursor_pos
+    assert (fake_view.to - fake_view.from)+2 == fake_view.height
+
+    // Move cursor to the end and test again
+    fake_view.cursor.pos.y = 14
+    original_cursor_pos = fake_view.cursor.pos.y
+    fake_view.center_text_around_cursor()
+
+    // Check if the cursor position remains unchanged
+    assert fake_view.cursor.pos.y == original_cursor_pos
+
+    // Check if the view is adjusted for the end of the document
+	// The '+5' is to account for the extra lines in the total
+    assert fake_view.from <= original_cursor_pos
+    assert fake_view.to+5 == fake_view.buffer.lines.len
+}


### PR DESCRIPTION
This seems to work the same as in Vim. I use it regularly there, so I thought I would add it to lilly also :)

That seems to be the way I am looking at these PR's...if I use the actions in Vim/NVim fairly often, then I try it with lilly. If it isn't implemented yet then I take a crack at it. Please let me know if you would prefer that I don't continue with this method, or if there is something more pressing that you would prefer I look at ;)