### PR TITLE
Feat/adjust line segments color for selection

### DIFF
--- a/src/view.v
+++ b/src/view.v
@@ -624,11 +624,14 @@ enum SegmentKind {
 }
 
 struct LineSegment {
-	start    int
-	end      int
-	typ      SegmentKind
-	fg_color Color
-	bg_color Color = Color{ 1, 1, 1 }
+	start            int
+	end              int
+	within_selection bool
+	selection_start  int
+	selection_end    int
+	typ              SegmentKind
+	fg_color         Color
+	bg_color         Color = Color{ 1, 1, 1 }
 }
 
 fn LineSegment.new_key(start int, end int) LineSegment {
@@ -645,6 +648,10 @@ fn LineSegment.new_string(start int, end int) LineSegment {
 
 fn LineSegment.new_comment(start int, end int) LineSegment {
 	return LineSegment{ start, end, .a_comment, Color{ 130, 130, 130 }, Color{ 1, 1, 1 } }
+}
+
+fn (mut line_segment LineSegment) accomodate_selection(selection_start int, selection_end Pos) {
+    // TODO(tauraamui): implement some kind of selection contents acknowledger thing
 }
 
 struct LineSelectionBounds {

--- a/src/view.v
+++ b/src/view.v
@@ -705,6 +705,12 @@ fn (mut line_segment LineSegment) accomodate_selection(line_y int, selection_sta
         return
     }
 
+    if selection_start.x < line_segment.start && selection_end.x > line_segment.start && selection_end.x <= line_segment.end {
+        line_segment.selection_start = line_segment.start
+        line_segment.selection_end = selection_end.x
+        return
+    }
+
     if selection_start.x > line_segment.start && selection_start.x < line_segment.end {
         line_segment.selection_start = selection_start.x
         if selection_end.x >= line_segment.end {

--- a/src/view.v
+++ b/src/view.v
@@ -635,19 +635,39 @@ struct LineSegment {
 }
 
 fn LineSegment.new_key(start int, end int) LineSegment {
-	return LineSegment{ start, end, .a_key, Color{ 255, 126, 182 }, Color{ 1, 1, 1 } }
+    return LineSegment{
+        start: start,
+        end: end,
+        typ: .a_key,
+        fg_color: Color{ 255, 126, 182 }
+    }
 }
 
 fn LineSegment.new_literal(start int, end int) LineSegment {
-	return LineSegment{ start, end, .a_lit, Color{ 87, 215, 217 }, Color{ 1, 1, 1 } }
+    return LineSegment{
+        start: start,
+        end: end,
+        typ: .a_lit,
+        fg_color: Color{ 87, 215, 217 }
+    }
 }
 
 fn LineSegment.new_string(start int, end int) LineSegment {
-	return LineSegment{ start, end, .a_string, Color{ 87, 215, 217 }, Color{ 1, 1, 1 } }
+    return LineSegment{
+        start: start,
+        end: end,
+        typ: .a_string,
+        fg_color: Color{ 87, 215, 217 }
+    }
 }
 
 fn LineSegment.new_comment(start int, end int) LineSegment {
-	return LineSegment{ start, end, .a_comment, Color{ 130, 130, 130 }, Color{ 1, 1, 1 } }
+    return LineSegment{
+        start: start,
+        end: end,
+        typ: .a_comment,
+        fg_color: Color{ 130, 130, 130 }
+    }
 }
 
 fn (mut line_segment LineSegment) accomodate_selection(selection_start int, selection_end Pos) {

--- a/src/view.v
+++ b/src/view.v
@@ -627,12 +627,13 @@ struct LineSegment {
 	start            int
 	end              int
 	line_y           int
-	within_selection bool
-	selection_start  int
-	selection_end    int
 	typ              SegmentKind
 	fg_color         Color
 	bg_color         Color = Color{ 1, 1, 1 }
+mut:
+	within_selection bool
+	selection_start  int
+	selection_end    int
 }
 
 fn LineSegment.new_key(start int, line_y int, end int) LineSegment {
@@ -676,6 +677,12 @@ fn LineSegment.new_comment(start int, line_y int, end int) LineSegment {
 }
 
 fn (mut line_segment LineSegment) accomodate_selection(line_y int, selection_start Pos, selection_end Pos) {
+    if line_segment.line_y < selection_start.y || line_segment.line_y > selection_end.y { return }
+    if selection_start.y != selection_end.y && line_segment.line_y > selection_start.y && line_segment.line_y < selection_end.y {
+        line_segment.selection_start = line_segment.start
+        line_segment.selection_end = line_segment.end
+        return
+    }
     // TODO(tauraamui): provide defer to set selection flag to true if values make sense for it to be
 }
 

--- a/src/view_test.v
+++ b/src/view_test.v
@@ -252,17 +252,17 @@ fn test_v_toggles_visual_mode_and_starts_selection() {
 fn resolve_test_syntax() workspace.Syntax {
     return json.decode(workspace.Syntax, '{
         "name": "test",
-        "keywords": ["for", "func"],
+        "keywords": ["for", "func", "print"],
         "literals": ["nil", "true", "false"]
     }') or { panic("failed to parse test syntax: ${err}") }
 }
 
 fn test_resolve_line_segments_and_change_colors_if_in_selection() {
     line := "for thing != nil { print(true) }"
-    line_segments, _ := resolve_line_segments(resolve_test_syntax(), line, false)
-    assert line_segments.len == 3
-    for line_segment in line_segments {
-        println("LINE SEGMENT: ${line_segment}")
+    mut line_segments, _ := resolve_line_segments(resolve_test_syntax(), line, 0, false)
+    assert line_segments.len == 4
+    for mut line_segment in line_segments {
+        line_segment.accomodate_selection(0, Pos{ 0, 0 }, Pos{ line.runes().len, 0 })
     }
     assert true == false // to force log output from this test to show in stdout
 }

--- a/src/view_test.v
+++ b/src/view_test.v
@@ -257,14 +257,27 @@ fn resolve_test_syntax() workspace.Syntax {
     }') or { panic("failed to parse test syntax: ${err}") }
 }
 
-fn test_resolve_line_segments_and_change_colors_if_in_selection() {
+fn test_line_segments_accomodate_selection_full_line() {
     line := "for thing != nil { print(true) }"
     mut line_segments, _ := resolve_line_segments(resolve_test_syntax(), line, 0, false)
     assert line_segments.len == 4
     for mut line_segment in line_segments {
         line_segment.accomodate_selection(0, Pos{ 0, 0 }, Pos{ line.runes().len, 0 })
+        assert line_segment.within_selection
     }
-    assert true == false // to force log output from this test to show in stdout
+}
+
+fn test_line_segments_accomodate_selection_when_selection_inside_span() {
+    line := "for thing != nil { print(true) }"
+    mut line_segments, _ := resolve_line_segments(resolve_test_syntax(), line, 0, false)
+    assert line_segments.len == 4
+    for i, mut line_segment in line_segments {
+        if i != 2 { continue }
+        line_segment.accomodate_selection(0, Pos{ 20, 0 }, Pos{ 23, 0 })
+        assert line_segment.within_selection
+        assert line_segment.selection_start == 20
+        assert line_segment.selection_end == 23
+    }
 }
 
 fn test_shift_v_toggles_visual_line_mode_and_starts_selection() {

--- a/src/view_test.v
+++ b/src/view_test.v
@@ -17,6 +17,7 @@ module main
 import arrays
 import lib.clipboard
 import lib.workspace
+import json
 import lib.draw
 import term.ui as tui
 
@@ -246,6 +247,20 @@ fn test_v_toggles_visual_mode_and_starts_selection() {
 
 	assert fake_view.cursor.selection_start() == Pos{ 6, 0 }
 	assert fake_view.cursor.selection_end() == Pos{ 12, 0 }
+}
+
+fn resolve_test_syntax() workspace.Syntax {
+    return json.decode(workspace.Syntax, '{
+        "name": "test",
+        "keywords": ["for", "func"],
+        "literals": ["nil", "true", "false"]
+    }') or { panic("failed to parse test syntax: ${err}") }
+}
+
+fn test_resolve_line_segments_and_change_colors_if_in_selection() {
+    line := "for thing != nil { print(true) }"
+    line_segments, _ := resolve_line_segments(resolve_test_syntax(), line, false)
+    assert line_segments == []
 }
 
 fn test_shift_v_toggles_visual_line_mode_and_starts_selection() {

--- a/src/view_test.v
+++ b/src/view_test.v
@@ -260,7 +260,11 @@ fn resolve_test_syntax() workspace.Syntax {
 fn test_resolve_line_segments_and_change_colors_if_in_selection() {
     line := "for thing != nil { print(true) }"
     line_segments, _ := resolve_line_segments(resolve_test_syntax(), line, false)
-    assert line_segments == []
+    assert line_segments.len == 3
+    for line_segment in line_segments {
+        println("LINE SEGMENT: ${line_segment}")
+    }
+    assert true == false // to force log output from this test to show in stdout
 }
 
 fn test_shift_v_toggles_visual_line_mode_and_starts_selection() {

--- a/src/view_test.v
+++ b/src/view_test.v
@@ -280,6 +280,29 @@ fn test_line_segments_accomodate_selection_when_selection_inside_span() {
     }
 }
 
+fn test_line_segments_accomodate_selection_when_selection_encompasses_multiple_spans() {
+    line := "for thing != nil { print(true) }"
+    mut line_segments, _ := resolve_line_segments(resolve_test_syntax(), line, 0, false)
+    assert line_segments.len == 4
+    for i, mut line_segment in line_segments {
+        if i == 0 || i == line_segments.len - 1 { continue }
+        line_segment.accomodate_selection(0, Pos{ 10, 0 }, Pos{ 23, 0 })
+        if i == 1 {
+            assert line_segment.within_selection
+            assert line_segment.selection_start == 13
+            assert line_segment.selection_end == 16
+            continue
+        }
+
+        if i == 2 {
+            assert line_segment.within_selection
+            assert line_segment.selection_start == 19
+            assert line_segment.selection_end == 23
+            continue
+        }
+    }
+}
+
 fn test_shift_v_toggles_visual_line_mode_and_starts_selection() {
 	mut clip := clipboard.new()
 	mut fake_view := View{ log: unsafe { nil }, mode: .normal, clipboard: mut clip }


### PR DESCRIPTION
Define segment method helper to provide easy way to account for current potentially multi line but partial selection of document in visual mode.