### PR TITLE
fix: swap params to be correct order

### DIFF
--- a/src/splash_view.v
+++ b/src/splash_view.v
@@ -37,7 +37,7 @@ mut:
 	leader_key  string
 }
 
-pub fn new_splash(leader_key string, commit_hash string) Viewable {
+pub fn new_splash(commit_hash string, leader_key string) Viewable {
 	mut splash := SplashScreen{
 		commit_hash: commit_hash
 		file_path: "**lss**"


### PR DESCRIPTION
Splashscreen was expecting the leader key param and the commit hash param in the wrong order which was effectively breaking main/core load behaviour.