### PR TITLE
Chord repeat zero fix

### DIFF
--- a/src/view.v
+++ b/src/view.v
@@ -1528,11 +1528,13 @@ fn (mut view View) l() {
 fn (mut view View) j() {
 	view.move_cursor_down(1)
 	view.clamp_cursor_x_pos()
+	view.clamp_cursor_within_document_bounds()
 }
 
 fn (mut view View) k() {
 	view.move_cursor_up(1)
 	view.clamp_cursor_x_pos()
+	view.clamp_cursor_within_document_bounds()
 }
 
 fn (mut view View) i() {

--- a/src/view_keybinds.v
+++ b/src/view_keybinds.v
@@ -144,7 +144,11 @@ fn (mut view View) on_key_down(e draw.Event, mut root Root) {
 					view.search()
 				}
 				48...48 {
-					view.zero()	
+					if view.chord.pending_repeat_amount() != '' {
+						view.chord.append_to_repeat_amount(e.ascii.ascii_str())
+					} else {
+						view.zero()
+					}
 				}
 				49...57 { // 0-9a
 					view.chord.append_to_repeat_amount(e.ascii.ascii_str())


### PR DESCRIPTION
I caused the error where any repeat amount that included a '0' wouldn't work correctly when I added the view.zero() functionality, so I figured I should fix it ;)  There was also a small error where Lilly would just shutdown if I used a 'repeated j()' command to jump down past the end of the file!! That is fixed now also.