### PR TITLE
Very small fix to allow compilation on windows

### DIFF
--- a/src/lib/clipboard/clipboard.v
+++ b/src/lib/clipboard/clipboard.v
@@ -7,5 +7,9 @@ mut:
 }
 
 pub fn new() Clipboard {
-	return new_clipboard()
+	$if windows {
+		return clipboard.new()
+	} $else {
+		return new_clipboard()
+	}
 }


### PR DESCRIPTION
This allows Lilly to compile and run on windows again. Lilly works on 'git-bash' and 'msys2' with this slight change, and the clipboard seems to work ok.