### PR TITLE
A fix for the gui after the new_context() changes

### DIFF
--- a/src/lib/draw/ctx.v
+++ b/src/lib/draw/ctx.v
@@ -24,6 +24,8 @@ pub:
 	b u8
 }
 
+pub type Runner = fn () !
+
 pub interface Drawer {
 mut:
 	draw_text(x int, y int, text string)

--- a/src/lib/draw/gui_d_gui.v
+++ b/src/lib/draw/gui_d_gui.v
@@ -7,7 +7,7 @@ import os
 
 struct Context {
 	user_data voidptr
-	frame_cb  fn (v voidptr)
+	frame_cb  fn (v voidptr) @[required]
 mut:
 	gg                         &gg.Context = unsafe { nil }
 	txt_cfg                    gx.TextCfg
@@ -16,7 +16,7 @@ mut:
 	text_draws_since_last_pass int
 }
 
-pub fn new_context(cfg Config) &Contextable {
+pub fn new_context(cfg Config) (&Contextable, Runner) {
 	mut ctx := &Context{
 		user_data: cfg.user_data
 		frame_cb:  cfg.frame_fn
@@ -31,10 +31,18 @@ pub fn new_context(cfg Config) &Contextable {
 		font_path:     os.resource_abs_path('../experiment/RobotoMono-Regular.ttf')
 		frame_fn:      frame
 	)
-	return ctx
+	return ctx, unsafe { ctx.run_wrapper }
 }
 
 const font_size = 16
+
+fn (mut ctx Context) run_wrapper() ! {
+    ctx.gg.run()
+}
+
+fn (mut ctx Context) render_debug() bool {
+    return true
+}
 
 fn frame(mut ctx Context) {
 	width := gg.window_size().width


### PR DESCRIPTION
This get 'compile-gui' compiling again on Linux/Windows, however I seem to have some issue still with no characters showing in the window, and input not seeming to work!? Do you get the same thing @tauraamui ?  Or do things work properly for you?

It is possible this is just an issue here as I run a non-standard setup on both Linux and Windows :)