### PR TITLE
Partial? Fix for panic when opening binary files

### DIFF
--- a/src/file_finder_modal.v
+++ b/src/file_finder_modal.v
@@ -136,7 +136,11 @@ fn (mut file_finder_modal FileFinderModal) on_key_down(e draw.Event, mut root Ro
 
 fn (mut file_finder_modal FileFinderModal) file_selected(mut root Root) {
 	file_paths := file_finder_modal.file_paths
-	root.open_file(file_paths[file_finder_modal.current_selection]) or { panic('${err}') }
+	selected_path := file_paths[file_finder_modal.current_selection]
+	if is_binary_file(selected_path) {
+		return
+	}
+	root.open_file(selected_path) or { panic('${err}') }
 }
 
 struct ScoredFilePath {


### PR DESCRIPTION
Not completely sure if this the right way to do this, but it seems to work for the few file types I have tested and directories (that is part of the problem...we may want to be able to traverse directories?). Anyways, nothing happens if you try to choose a binary/non-text file to open.

Perhaps we should also change the 'Search:' line to a different color, or show some indication that the open failed?

Fixes(kindof) #191  (LIL-59)