### PR TITLE
Feat/add feat flag for migrating to gap buffer

### DIFF
--- a/src/editor.v
+++ b/src/editor.v
@@ -27,6 +27,7 @@ mut:
 	clipboard                         clipboardv2.Clipboard
 	view                              &Viewable = unsafe { nil }
 	debug_view                        bool
+	use_gap_buffer                    bool
 	views                             []Viewable
 	buffers                           []buffer.Buffer
 	file_finder_modal_open            bool
@@ -46,10 +47,16 @@ mut:
 	quit()
 }
 
-pub fn open_editor(mut _log log.Log, mut _clipboard clipboardv2.Clipboard, commit_hash string, file_path string, workspace_root_dir string) !&Editor {
+pub fn open_editor(
+	mut _log log.Log,
+	mut _clipboard clipboardv2.Clipboard,
+	commit_hash string, file_path string,
+	workspace_root_dir string, use_gap_buffer bool,
+) !&Editor {
 	mut editor := Editor{
 		log: _log
 		clipboard:         _clipboard
+		use_gap_buffer: use_gap_buffer
 		file_finder_modal: unsafe { nil }
 		inactive_buffer_finder_modal: unsafe { nil }
 	}
@@ -120,7 +127,7 @@ fn (mut editor Editor) open_file(path string) ! {
 	mut buff := buffer.Buffer{
 		file_path: path
 	}
-	buff.load_from_path() or { return err }
+	buff.load_from_path(editor.use_gap_buffer) or { return err }
 	editor.buffers << buff
 	editor.views << open_view(mut editor.log, editor.workspace.config, editor.workspace.branch(), editor.workspace.syntaxes(),
 		editor.clipboard, mut &editor.buffers[editor.buffers.len - 1])

--- a/src/lib/buffer/buffer.v
+++ b/src/lib/buffer/buffer.v
@@ -13,18 +13,18 @@ mut:
 	// line_tracker LineTracker
 }
 
-pub fn (mut buffer Buffer) load_from_path() ! {
+pub fn (mut buffer Buffer) load_from_path(use_gap_buffer bool) ! {
 	buffer.lines = os.read_lines(buffer.file_path) or {
 		return error('unable to open file ${buffer.file_path} ${err}')
 	}
 	if buffer.lines.len == 0 {
 		buffer.lines = ['']
 	}
-	// TODO(tauraamui): enable this additional loading under a flag
-	/*
-	file_contents := os.read_file(buffer.file_path) or { return error("unable to open file ${buffer.file_path}: ${err}") }
-	buffer.c_buffer = GapBuffer.new(file_contents)
-	*/
+
+	if use_gap_buffer {
+		file_contents := os.read_file(buffer.file_path) or { return error("unable to open file ${buffer.file_path}: ${err}") }
+		buffer.c_buffer = GapBuffer.new(file_contents)
+	}
 }
 
 pub fn (mut buffer Buffer) iterator() LineIterator {

--- a/src/lib/buffer/buffer.v
+++ b/src/lib/buffer/buffer.v
@@ -1,6 +1,5 @@
 module buffer
 
-import history { History }
 import os
 
 pub struct Buffer {

--- a/src/lib/buffer/buffer.v
+++ b/src/lib/buffer/buffer.v
@@ -9,7 +9,8 @@ pub mut:
 	lines            []string
 	auto_close_chars []string
 mut:
-	c_buffer   GapBuffer
+	use_gap_buffer   bool
+	c_buffer         GapBuffer
 	// line_tracker LineTracker
 }
 
@@ -22,17 +23,40 @@ pub fn (mut buffer Buffer) load_from_path(use_gap_buffer bool) ! {
 	}
 
 	if use_gap_buffer {
+		buffer.use_gap_buffer = use_gap_buffer
 		file_contents := os.read_file(buffer.file_path) or { return error("unable to open file ${buffer.file_path}: ${err}") }
 		buffer.c_buffer = GapBuffer.new(file_contents)
 	}
 }
 
-pub fn (mut buffer Buffer) iterator() LineIterator {
-	return new_iterator(buffer.c_buffer)
+pub interface LineIterator {
+mut:
+	next() ?string
 }
 
-fn new_iterator(buffer GapBuffer) LineIterator {
-	return LineIterator{
+struct LineListIterator {
+mut:
+	index    int
+	data_ref []string
+}
+
+pub fn (mut iter LineListIterator) next() ?string {
+	if iter.index >= iter.data_ref.len {
+		return none
+	}
+	defer { iter.index += 1 }
+	return iter.data_ref[iter.index]
+}
+
+pub fn (mut buffer Buffer) iterator() LineIterator {
+	if buffer.use_gap_buffer {
+		return new_iterator(buffer.c_buffer)
+	}
+	return LineListIterator{ data_ref: buffer.lines }
+}
+
+fn new_iterator(buffer GapBuffer) GapBufferLineIterator {
+	return GapBufferLineIterator{
 		data: buffer.str()
 	}
 }

--- a/src/lib/buffer/gap_buffer.v
+++ b/src/lib/buffer/gap_buffer.v
@@ -84,7 +84,7 @@ fn (mut gap_buffer GapBuffer) resize_if_full() {
 	gap_buffer.data = data_dest
 }
 
-pub struct LineIterator {
+pub struct GapBufferLineIterator {
 	data       string
 mut:
 	line_number int
@@ -93,7 +93,7 @@ mut:
 	done bool
 }
 
-pub fn (mut line_iter LineIterator) next() ?string {
+pub fn (mut line_iter GapBufferLineIterator) next() ?string {
 	if line_iter.done {
 		line_iter.line_start = 0
 		line_iter.line_end = 0

--- a/src/main.v
+++ b/src/main.v
@@ -92,9 +92,12 @@ mut:
 	capture_panics                   bool
 	long_disable_panic_capture_flag  string
 	short_disable_panic_capture_flag string
+	disable_panic_capture            bool
 	long_log_level_label_flag        string
 	short_log_level_label_flag       string
-	disable_panic_capture            bool
+	long_gap_buffer_toggle_flag      string
+	short_gap_buffer_toggle_flag     string
+	use_gap_buffer                   bool
 }
 
 fn resolve_options_from_args(args []string) Options {
@@ -116,6 +119,8 @@ fn resolve_options_from_args(args []string) Options {
 		short_disable_panic_capture_flag: 'dpc'
 		long_log_level_label_flag:        'log-level'
 		short_log_level_label_flag:       'll'
+		long_gap_buffer_toggle_flag:      'use-gap-buffer'
+		short_gap_buffer_toggle_flag:     'ugb'
 	}
 
 	opts.show_help = '--${opts.long_show_help_flag}' in flags
@@ -146,6 +151,9 @@ fn resolve_options_from_args(args []string) Options {
 		opts.log_level = log.level_from_tag(log_level_option) or { log.Level.disabled }
 	}
 
+	opts.use_gap_buffer = '--${opts.long_gap_buffer_toggle_flag}' in flags
+		|| '-${opts.short_gap_buffer_toggle_flag}' in flags
+
 	return opts
 }
 
@@ -160,6 +168,7 @@ fn (opts Options) flags_str() string {
 	sb.write_string('\n\t-${opts.short_render_debug_mode_flag}, --${opts.long_render_debug_mode_flag} (enable render debug mode)')
 	sb.write_string('\n\t-${opts.short_disable_panic_capture_flag}, --${opts.long_disable_panic_capture_flag} (disable persistance of panic stack trace output)')
 	sb.write_string('\n\t-${opts.short_log_level_label_flag}, --${opts.long_log_level_label_flag} [disabled | fatal | error | warn | info | debug] (set the minimum log level to output from)')
+	sb.write_string('\n\t-${opts.short_gap_buffer_toggle_flag}, --${opts.long_gap_buffer_toggle_flag} (enable using gap buffer)')
 	return sb.str()
 }
 

--- a/src/main.v
+++ b/src/main.v
@@ -270,7 +270,7 @@ fn main() {
 		'', ''
 	}
 	mut clip := clipboardv2.new()
-	app.editor = open_editor(mut l, mut clip, gitcommit_hash, file_path, workspace_path) or {
+	app.editor = open_editor(mut l, mut clip, gitcommit_hash, file_path, workspace_path, opts.use_gap_buffer) or {
 		print_and_exit('${err}')
 		unsafe { nil }
 	}

--- a/src/view.v
+++ b/src/view.v
@@ -19,7 +19,6 @@ import term.ui as tui
 import log
 import datatypes
 import strconv
-import strings
 import regex
 import lib.clipboardv2
 import lib.buffer


### PR DESCRIPTION
This change adds a new flag:

`--use-gap-buffer` or `-ugb`

This currently just changes the buffer's iterator to either loop over the gap buffer data or the existing list of strings document structure. The iterator is not used by the renderer, and the gap buffer is not currently edited.