### PR TITLE
Initial setting of 'dirty' bits for edited files

### DIFF
--- a/src/debug_view.v
+++ b/src/debug_view.v
@@ -22,6 +22,6 @@ fn (mut debug Debug) draw(mut ctx draw.Contextable) {
 
 fn (mut debug Debug) on_key_down(e draw.Event, mut r Root) {
 	if e.code == .escape {
-		r.quit()
+		r.quit() or {}
 	}
 }

--- a/src/editor_test.v
+++ b/src/editor_test.v
@@ -1,0 +1,48 @@
+module main
+import log
+import lib.clipboardv2
+import lib.buffer
+import lib.workspace
+
+fn test_quit_with_dirty_buffers() {
+    mut editor := Editor{
+        log: log.Log{}
+        clipboard: clipboardv2.new()
+        use_gap_buffer: true
+        file_finder_modal: unsafe { nil }
+        inactive_buffer_finder_modal: unsafe { nil }
+    }
+
+    // Add a view with a dirty buffer
+    mut buff := buffer.Buffer{
+        file_path: 'test.txt'
+    }
+    buff.dirty = true
+    editor.buffers << buff
+    editor.views << open_view(mut editor.log, workspace.Config{}, '', [], editor.clipboard, mut &editor.buffers[0])
+
+    // Attempt to quit should return error
+    mut got_expected_error := false
+    editor.quit() or {
+        got_expected_error = err.msg() == "Cannot quit: 1 unsaved buffer(s). Save changes or use :q! to force quit"
+        return
+    }
+    assert got_expected_error
+}
+
+fn test_quit_with_clean_buffers() {
+    mut editor := Editor{
+        log: log.Log{}
+        clipboard: clipboardv2.new()
+        use_gap_buffer: true
+    }
+
+    mut buff := buffer.Buffer{
+        file_path: 'test.txt'
+    }
+    editor.buffers << buff
+    editor.views << open_view(mut editor.log, workspace.Config{}, '', [], editor.clipboard, mut &editor.buffers[0])
+
+    // Clean buffers should allow quit
+    editor.quit()!
+}

--- a/src/lib/buffer/buffer.v
+++ b/src/lib/buffer/buffer.v
@@ -7,6 +7,7 @@ pub mut:
 	auto_close_chars []string
 	lines            []string
 	use_gap_buffer   bool
+	dirty            bool
 mut:
 	c_buffer         GapBuffer
 	// line_tracker LineTracker

--- a/src/splash_view.v
+++ b/src/splash_view.v
@@ -176,7 +176,7 @@ pub fn (mut splash SplashScreen) on_key_down(e draw.Event, mut root Root) {
 				reset_leader_state(mut splash.leader_state)
 				return
 			}
-			root.quit()
+			root.quit() or {}
 		}
 		// leader_key { splash.leader_mode = true }
 		// TODO(tauraamui): move to f() method, this line is a too complicated/long statement now

--- a/src/status_line.v
+++ b/src/status_line.v
@@ -29,6 +29,7 @@ struct Status {
 	file_name  string
 	selection  SearchSelection
 	git_branch string
+	dirty      bool
 }
 
 fn draw_status_line(mut ctx draw.Contextable, status Status) {
@@ -44,7 +45,8 @@ fn draw_status_line(mut ctx draw.Contextable, status Status) {
 
 	// if filename provided, render its segment next
 	if status.file_name.len > 0 {
-		offset += draw_file_name_segment(mut ctx, offset, y, status.file_name)
+        dirty_indicator := if status.dirty { ' [+]' } else { '' }
+        offset += draw_file_name_segment(mut ctx, offset, y, status.file_name + dirty_indicator)
 	}
 
 	// if search selection active/provided, render it's segment next

--- a/src/view.v
+++ b/src/view.v
@@ -406,7 +406,15 @@ fn (mut cmd_buf CmdBuffer) prepare_for_input() {
 fn (mut cmd_buf CmdBuffer) exec(mut view View, mut root Root) {
 	match view.cmd_buf.line {
 		':q' {
-			root.quit()
+			root.quit() or {
+				cmd_buf.code = .unsuccessful
+				cmd_buf.set_error(err.msg())
+				return
+			}
+			cmd_buf.code = .successful
+		}
+		':q!' {
+			root.force_quit()
 			cmd_buf.code = .successful
 		}
 		':toggle whitespace' {
@@ -424,12 +432,16 @@ fn (mut cmd_buf CmdBuffer) exec(mut view View, mut root Root) {
 		':w' {
 			cmd_buf.code = .successful
 			view.save_file() or { cmd_buf.code = .unsuccessful }
+			if cmd_buf.code == .successful {
+				view.buffer.dirty = false
+			}
 		}
 		':wq' {
 			cmd_buf.code = .successful
 			view.save_file() or { cmd_buf.code = .unsuccessful }
+			view.buffer.dirty = false
 			if cmd_buf.code == .successful {
-				root.quit()
+				root.quit() or {}
 			}
 		}
 		':version' {
@@ -625,7 +637,7 @@ fn (mut view View) draw(mut ctx draw.Contextable) {
 		active:  view.leader_state.mode == .search
 		total:   view.search.total_finds
 		current: view.search.current_find.match_index
-	}, view.branch})
+	}, view.branch, view.buffer.dirty})
 
 	view.draw_bottom_bar_of_command_or_search(mut ctx)
 
@@ -1334,11 +1346,13 @@ fn (mut view View) insert_text_gb(s string) {
 			view.cursor.pos.x = 0
 		}
 	}
+	view.buffer.dirty = true
 }
 
 fn (mut view View) insert_text_lb(s string) {
 	y := view.cursor.pos.y
 	line := view.buffer.lines[y]
+	view.buffer.dirty = true
 	if line.len == 0 {
 		view.buffer.lines[y] = '${s}'
 		view.cursor.pos.x = s.runes().len
@@ -1981,6 +1995,7 @@ fn (mut view View) y() {
 fn (mut view View) enter() {
 	y := view.cursor.pos.y
 	mut whitespace_prefix := resolve_whitespace_prefix(view.buffer.lines[y])
+	view.buffer.dirty = true
 	if whitespace_prefix.len == view.buffer.lines[y].len { // if the current line only has whitespace on it
 		view.buffer.lines[y] = ''
 		whitespace_prefix = ''
@@ -2013,6 +2028,7 @@ fn (mut view View) backspace() {
 	}
 
 	mut line := view.buffer.lines[y]
+	view.buffer.dirty = true
 
 	if view.cursor.pos.x == 0 {
 		previous_line := view.buffer.lines[y - 1]


### PR DESCRIPTION
The simple case of editing one file, or more, and then trying to quit, works. Hitting undo to back out of the edits doesn't clear the dirty bit yet, as the undo stuff isn't working right now (as far as I can tell).

I think some enhancements could include a list of dirty files to choose from when we try to quit? And then a 'save all' option also.  As it is right now, if you edit a few files then try to quit, you have to remember which files were edited and go back into each one to save it! This is not ideal, of course. Thoughts? (Or we could discuss in the issue #209 )