### PR TITLE
Refactor/re structure how views and buffers are stored

### DIFF
--- a/src/lib/buffer/buffer.v
+++ b/src/lib/buffer/buffer.v
@@ -2,8 +2,11 @@ module buffer
 
 import lib.search
 
+pub type UUID_t = string
+
 pub struct Buffer {
 pub:
+	uuid      UUID_t
 	file_path string
 pub mut:
 	auto_close_chars []string

--- a/src/lib/buffer/buffer_test.v
+++ b/src/lib/buffer/buffer_test.v
@@ -1,23 +1,23 @@
 module buffer
 
 fn test_buffer_load_from_path() {
-	read_lines := fn (path string) ![]string {
+	line_reader := fn (path string) ![]string {
 		return ["1. This is a first line", "2. This is a second line", "3. This is a third line"]
 	}
 
-	mut buffer := Buffer{}
-	buffer.load_from_path(read_lines, false)!
+	mut buffer := Buffer.new("", false)
+	buffer.read_lines(line_reader)!
 
 	assert buffer.lines == ["1. This is a first line", "2. This is a second line", "3. This is a third line"]
 }
 
 fn test_buffer_load_from_path_and_iterate() {
-	read_lines := fn (path string) ![]string {
+	line_reader := fn (path string) ![]string {
 		return ["1. This is a first line", "2. This is a second line", "3. This is a third line"]
 	}
 
-	mut buffer := Buffer{}
-	buffer.load_from_path(read_lines, false)!
+	mut buffer := Buffer.new("", false)
+	buffer.read_lines(line_reader)!
 
 	assert buffer.lines == ["1. This is a first line", "2. This is a second line", "3. This is a third line"]
 
@@ -36,12 +36,12 @@ fn test_buffer_load_from_path_and_iterate() {
 }
 
 fn test_buffer_load_from_path_with_gap_buffer_and_iterate() {
-	read_lines := fn (path string) ![]string {
+	line_reader := fn (path string) ![]string {
 		return ["1. This is a first line", "2. This is a second line", "3. This is a third line"]
 	}
 
-	mut buffer := Buffer{}
-	buffer.load_from_path(read_lines, true)!
+	mut buffer := Buffer.new("", true)
+	buffer.read_lines(line_reader)!
 
 	mut iteration_count := 0
 	for id, line in buffer.line_iterator() {
@@ -58,12 +58,12 @@ fn test_buffer_load_from_path_with_gap_buffer_and_iterate() {
 }
 
 fn test_buffer_load_from_path_and_iterate_over_pattern_matches() {
-	read_lines := fn (path string) ![]string {
+	line_reader := fn (path string) ![]string {
 		return ["1. This is a first line", "// TODO(tauraamui) [30/01/25]: this line has a comment to find", "2. This is a second line", "3. This is a third line"]
 	}
 
-	mut buffer := Buffer{}
-	buffer.load_from_path(read_lines, false)!
+	mut buffer := Buffer.new("", false)
+	buffer.read_lines(line_reader)!
 
 	mut iteration_count := 0
 	mut found_match_count := 0
@@ -83,12 +83,12 @@ fn test_buffer_load_from_path_and_iterate_over_pattern_matches() {
 }
 
 fn test_buffer_load_from_path_with_gap_buffer_and_iterate_over_pattern_matches() {
-	read_lines := fn (path string) ![]string {
+	line_reader := fn (path string) ![]string {
 		return ["1. This is a first line", "// TODO(tauraamui) [30/01/25]: this line has a comment to find", "2. This is a second line", "3. This is a third line"]
 	}
 
-	mut buffer := Buffer{}
-	buffer.load_from_path(read_lines, true)!
+	mut buffer := Buffer.new("", true)
+	buffer.read_lines(line_reader)!
 
 	mut iteration_count := 0
 	mut found_match_count := 0
@@ -109,7 +109,7 @@ fn test_buffer_load_from_path_with_gap_buffer_and_iterate_over_pattern_matches()
 
 
 fn test_buffer_insert_text() {
-	mut buffer := Buffer{}
+	mut buffer := Buffer.new("", true)
 	buffer.c_buffer = GapBuffer.new("")
 
 	for r in "Some text to insert!".runes() { buffer.c_buffer.insert(r) }
@@ -118,7 +118,7 @@ fn test_buffer_insert_text() {
 }
 
 fn test_buffer_enter_inserts_newline_line() {
-	mut buffer := Buffer{ use_gap_buffer: true }
+	mut buffer := Buffer.new("", true)
 	buffer.c_buffer = GapBuffer.new("1. first line\n2. second line\n3. third line")
 	buffer.write_at(lf, Pos{ x: 4, y: 0 })
 	assert buffer.str() == "1. f\nirst line\n2. second line\n3. third line"

--- a/src/lilly.v
+++ b/src/lilly.v
@@ -21,8 +21,6 @@ import lib.clipboardv2
 import lib.workspace
 import lib.draw
 
-type BufferGuid_t = string
-
 @[heap]
 struct Lilly {
 mut:
@@ -34,7 +32,7 @@ mut:
 	views                             []Viewable
 	buffers                           []buffer.Buffer
 	file_buffers                      map[string]buffer.Buffer
-	buffer_views                      map[BufferGuid_t]Viewable
+	buffer_views                      map[buffer.UUID_t]Viewable
 	file_finder_modal_open            bool
 	file_finder_modal                 Viewable
 	inactive_buffer_finder_modal_open bool

--- a/src/lilly.v
+++ b/src/lilly.v
@@ -121,21 +121,21 @@ fn (mut lilly Lilly) open_file(path string) ! {
 	return lilly.open_file_with_reader(path, os.read_lines)
 }
 
-fn (mut lilly Lilly) open_file_with_reader_v2(path string, read_lines fn (path string) ![]string) ! {
+fn (mut lilly Lilly) open_file_with_reader_v2(path string, line_reader fn (path string) ![]string) ! {
 	defer {
 		lilly.close_file_finder()
 		lilly.close_inactive_buffer_finder()
 	}
 
-	mut buff := buffer.Buffer{ file_path: path }
-	buff.load_from_path(read_lines, lilly.use_gap_buffer) or { return err }
+	mut buff := buffer.Buffer.new(path, lilly.use_gap_buffer)
+	buff.read_lines(line_reader) or { return err }
 
 	lilly.file_buffers[buff.file_path] = buff
 	lilly.buffer_views["ijiwefjiewjfijefoie"] = open_view(mut lilly.log, lilly.workspace.config, lilly.workspace.branch(),
 				lilly.workspace.syntaxes(), lilly.clipboard, mut buff)
 }
 
-fn (mut lilly Lilly) open_file_with_reader(path string, read_lines fn (path string) ![]string) ! {
+fn (mut lilly Lilly) open_file_with_reader(path string, line_reader fn (path string) ![]string) ! {
 	defer {
 		lilly.close_file_finder()
 		lilly.close_inactive_buffer_finder()
@@ -160,10 +160,8 @@ fn (mut lilly Lilly) open_file_with_reader(path string, read_lines fn (path stri
 	}
 
 	// neither existing view nor buffer was found, oh well, just load it then :)
-	mut buff := buffer.Buffer{
-		file_path: path
-	}
-	buff.load_from_path(read_lines, lilly.use_gap_buffer) or { return err }
+	mut buff := buffer.Buffer.new(path, lilly.use_gap_buffer)
+	buff.read_lines(line_reader) or { return err }
 	lilly.buffers << buff
 	lilly.views << open_view(mut lilly.log, lilly.workspace.config, lilly.workspace.branch(), lilly.workspace.syntaxes(),
 		lilly.clipboard, mut &lilly.buffers[lilly.buffers.len - 1])

--- a/src/lilly.v
+++ b/src/lilly.v
@@ -106,7 +106,18 @@ fn is_binary_file(path string) bool {
     return (f64(non_text_bytes) / f64(bytes_read)) > 0.3
 }
 
+fn (mut lilly Lilly) open_file_v2(path string) ! {
+	defer {
+		lilly.close_file_finder()
+		lilly.close_inactive_buffer_finder()
+	}
+}
+
 fn (mut lilly Lilly) open_file(path string) ! {
+	return lilly.open_file_with_reader(path, os.read_lines)
+}
+
+fn (mut lilly Lilly) open_file_with_reader(path string, read_lines fn (path string) ![]string) ! {
 	defer {
 		lilly.close_file_finder()
 		lilly.close_inactive_buffer_finder()
@@ -134,7 +145,7 @@ fn (mut lilly Lilly) open_file(path string) ! {
 	mut buff := buffer.Buffer{
 		file_path: path
 	}
-	buff.load_from_path(os.read_lines, lilly.use_gap_buffer) or { return err }
+	buff.load_from_path(read_lines, lilly.use_gap_buffer) or { return err }
 	lilly.buffers << buff
 	lilly.views << open_view(mut lilly.log, lilly.workspace.config, lilly.workspace.branch(), lilly.workspace.syntaxes(),
 		lilly.clipboard, mut &lilly.buffers[lilly.buffers.len - 1])

--- a/src/lilly.v
+++ b/src/lilly.v
@@ -128,7 +128,8 @@ fn (mut lilly Lilly) open_file_with_reader_v2(path string, line_reader fn (path 
 	}
 
 	if mut existing_file_buff := lilly.file_buffers[path] {
-		if existing_file_buff.uuid in lilly.buffer_views {
+		if existing_view := lilly.buffer_views[existing_file_buff.uuid] {
+			lilly.view = existing_view
 			return
 		}
 		lilly.view = open_view(mut lilly.log, lilly.workspace.config, lilly.workspace.branch(),

--- a/src/lilly.v
+++ b/src/lilly.v
@@ -144,7 +144,7 @@ fn (mut lilly Lilly) open_file_with_reader(path string, line_reader fn (path str
 	// find existing view which has that file open
 	for i, view in lilly.views {
 		if view.file_path == path {
-			lilly.view = &lilly.views[i + 1]
+			lilly.view = &lilly.views[i]
 			return
 		}
 	}

--- a/src/lilly.v
+++ b/src/lilly.v
@@ -110,14 +110,10 @@ fn is_binary_file(path string) bool {
 }
 
 fn (mut lilly Lilly) open_file_v2(path string) ! {
-	defer {
-		lilly.close_file_finder()
-		lilly.close_inactive_buffer_finder()
-	}
+	return lilly.open_file_with_reader_v2(path, os.read_lines)
 }
 
 fn (mut lilly Lilly) open_file(path string) ! {
-	lilly.open_file_with_reader_v2(path, os.read_lines)!
 	return lilly.open_file_with_reader(path, os.read_lines)
 }
 

--- a/src/lilly.v
+++ b/src/lilly.v
@@ -124,7 +124,7 @@ fn (mut lilly Lilly) open_file_with_reader(path string, read_lines fn (path stri
 	}
 
 	// find existing view which has that file open
-	for i, view in lilly.views[1..] {
+	for i, view in lilly.views {
 		if view.file_path == path {
 			lilly.view = &lilly.views[i + 1]
 			return

--- a/src/lilly.v
+++ b/src/lilly.v
@@ -130,8 +130,8 @@ fn (mut lilly Lilly) open_file_with_reader_v2(path string, line_reader fn (path 
 	mut buff := buffer.Buffer.new(path, lilly.use_gap_buffer)
 	buff.read_lines(line_reader) or { return err }
 
-	lilly.file_buffers[buff.file_path] = buff
-	lilly.buffer_views["ijiwefjiewjfijefoie"] = open_view(mut lilly.log, lilly.workspace.config, lilly.workspace.branch(),
+	lilly.file_buffers[path] = buff
+	lilly.buffer_views[buff.uuid] = open_view(mut lilly.log, lilly.workspace.config, lilly.workspace.branch(),
 				lilly.workspace.syntaxes(), lilly.clipboard, mut buff)
 }
 

--- a/src/lilly_test.v
+++ b/src/lilly_test.v
@@ -53,6 +53,32 @@ fn test_lilly_opens_file_loads_into_buffer_and_view() {
 	assert lilly.buffers.len == 1
 }
 
+fn test_lilly_open_file_v2_loads_into_file_buffer_and_buffer_view_maps() {
+	mut clip := clipboardv2.new()
+	mut lilly := Lilly{
+		clipboard: mut clip
+		file_finder_modal: unsafe { nil }
+		inactive_buffer_finder_modal: unsafe { nil }
+		todo_comments_finder_modal: unsafe { nil }
+	}
+
+	mut m_line_reader := MockLineReader{
+		line_data: ["This is a fake document that doesn't exist on disk anywhere"]
+	}
+
+	assert lilly.views.len == 0
+	assert lilly.buffers.len == 0
+
+	lilly.open_file_with_reader_v2("test-file.txt", m_line_reader.read_lines) or { assert false }
+
+	assert m_line_reader.given_path == "test-file.txt"
+	assert lilly.views.len   == 0
+	assert lilly.buffers.len == 0
+
+	file_buff := lilly.file_buffers["test-file.txt"] or { assert false, "failed to find buffer instance for path: test-file.txt" }
+	_ := lilly.buffer_views[file_buff.uuid]          or { assert false, "failed to find view instance for buffer of uuid: ${file_buff.uuid}" }
+}
+
 // TODO(tauraamui) [12/02/2025] something is horrendously broken with the below tests, its so bad that its making the
 //                              v test suite runner have some kind of stroke for all of the other asserts in this file...
 /*

--- a/src/lilly_test.v
+++ b/src/lilly_test.v
@@ -18,6 +18,43 @@ import lib.clipboardv2
 import lib.buffer
 import lib.workspace
 
+@[heap]
+struct MockLineReader {
+	line_data []string
+mut:
+	given_path string
+}
+
+fn (mut m_line_reader MockLineReader) read_lines(path string) ![]string {
+	m_line_reader.given_path = path
+	return m_line_reader.line_data
+}
+
+fn test_something_to_be_false() {
+	mut clip := clipboardv2.new()
+	mut lilly := Lilly{
+		clipboard: mut clip
+		file_finder_modal: unsafe { nil }
+		inactive_buffer_finder_modal: unsafe { nil }
+		todo_comments_finder_modal: unsafe { nil }
+	}
+
+	mut m_line_reader := MockLineReader{
+		line_data: ["This is a fake document that doesn't exist on disk anywhere"]
+	}
+
+	assert lilly.views.len == 0
+	assert lilly.buffers.len == 0
+
+	lilly.open_file_with_reader("test-file.txt", m_line_reader.read_lines) or { assert false }
+
+	assert lilly.views.len   == 1
+	assert lilly.buffers.len == 1
+}
+
+// TODO(tauraamui) [12/02/2025] something is horrendously broken with the below tests, its so bad that its making the
+//                              v test suite runner have some kind of stroke for all of the other asserts in this file...
+/*
 fn test_quit_with_dirty_buffers() {
     mut lilly := Lilly{
         log: log.Log{}
@@ -38,6 +75,7 @@ fn test_quit_with_dirty_buffers() {
     // Attempt to quit should return error
     mut got_expected_error := false
     lilly.quit() or {
+    	println(err.msg())
         got_expected_error = err.msg() == "Cannot quit: 1 unsaved buffer(s). Save changes or use :q! to force quit"
         return
     }
@@ -60,3 +98,4 @@ fn test_quit_with_clean_buffers() {
     // Clean buffers should allow quit
     lilly.quit()!
 }
+*/

--- a/src/lilly_test.v
+++ b/src/lilly_test.v
@@ -30,7 +30,7 @@ fn (mut m_line_reader MockLineReader) read_lines(path string) ![]string {
 	return m_line_reader.line_data
 }
 
-fn test_something_to_be_false() {
+fn test_lilly_opens_file_loads_into_buffer_and_view() {
 	mut clip := clipboardv2.new()
 	mut lilly := Lilly{
 		clipboard: mut clip
@@ -48,6 +48,7 @@ fn test_something_to_be_false() {
 
 	lilly.open_file_with_reader("test-file.txt", m_line_reader.read_lines) or { assert false }
 
+	assert m_line_reader.given_path == "test-file.txt"
 	assert lilly.views.len   == 1
 	assert lilly.buffers.len == 1
 }

--- a/src/lilly_test.v
+++ b/src/lilly_test.v
@@ -53,6 +53,37 @@ fn test_lilly_opens_file_loads_into_buffer_and_view() {
 	assert lilly.buffers.len == 1
 }
 
+fn test_lilly_opens_file_loads_into_buffer_and_view_if_done_twice_does_not_create_extra_instances() {
+	mut clip := clipboardv2.new()
+	mut lilly := Lilly{
+		clipboard: mut clip
+		file_finder_modal: unsafe { nil }
+		inactive_buffer_finder_modal: unsafe { nil }
+		todo_comments_finder_modal: unsafe { nil }
+	}
+
+	mut m_line_reader := MockLineReader{
+		line_data: ["This is a fake document that doesn't exist on disk anywhere"]
+	}
+
+	assert lilly.views.len == 0
+	assert lilly.buffers.len == 0
+	assert lilly.view.file_path == ""
+
+	lilly.open_file_with_reader("test-file.txt", m_line_reader.read_lines) or { assert false }
+
+	assert m_line_reader.given_path == "test-file.txt"
+	assert lilly.views.len   == 1
+	assert lilly.buffers.len == 1
+	assert lilly.view.file_path == "test-file.txt"
+
+	lilly.open_file_with_reader("test-file.txt", m_line_reader.read_lines) or { assert false }
+	assert lilly.views.len   == 1
+	assert lilly.buffers.len == 1
+	assert lilly.view.file_path == "test-file.txt"
+}
+
+
 fn test_lilly_open_file_v2_loads_into_file_buffer_and_buffer_view_maps() {
 	mut clip := clipboardv2.new()
 	mut lilly := Lilly{

--- a/src/lilly_test.v
+++ b/src/lilly_test.v
@@ -13,9 +13,7 @@
 // limitations under the License.
 
 module main
-import log
 import lib.clipboardv2
-import lib.buffer
 import lib.workspace
 
 @[heap]
@@ -68,7 +66,6 @@ fn test_lilly_opens_file_loads_into_buffer_and_view_if_done_twice_does_not_creat
 
 	assert lilly.views.len == 0
 	assert lilly.buffers.len == 0
-	assert lilly.view.file_path == ""
 
 	lilly.open_file_with_reader("test-file.txt", m_line_reader.read_lines) or { assert false }
 
@@ -107,7 +104,8 @@ fn test_lilly_open_file_v2_loads_into_file_buffer_and_buffer_view_maps() {
 	assert lilly.buffers.len == 0
 
 	file_buff := lilly.file_buffers["test-file.txt"] or { assert false, "failed to find buffer instance for path: test-file.txt" }
-	_ := lilly.buffer_views[file_buff.uuid]          or { assert false, "failed to find view instance for buffer of uuid: ${file_buff.uuid}" }
+	buff_view := lilly.buffer_views[file_buff.uuid]  or { assert false, "failed to find view instance for buffer of uuid: ${file_buff.uuid}" }
+	assert lilly.view == buff_view
 }
 
 // TODO(tauraamui) [12/02/2025] something is horrendously broken with the below tests, its so bad that its making the

--- a/src/view_gap_buffer_test.v
+++ b/src/view_gap_buffer_test.v
@@ -30,9 +30,9 @@ fn test_insert_text() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("1. first line\n2. second line")
 
@@ -51,9 +51,9 @@ fn test_insert_tab() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("1. first line\n2. second line")
 
@@ -76,9 +76,9 @@ fn test_shift_o_inserts_empty_line_above_current() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("1. first line\n2. second line\n3. third line")
 
@@ -103,9 +103,9 @@ fn test_shift_o_inserts_empty_line_above_current_first_line_of_document() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("1. first line\n2. second line\n3. third line")
 
@@ -130,9 +130,9 @@ fn test_o_inserts_empty_line_below_current() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("1. first line\n2. second line\n3. third line")
 
@@ -157,9 +157,9 @@ fn test_o_inserts_empty_line_below_current_last_line_of_document() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("1. first line\n2. second line\n3. third line")
 
@@ -184,9 +184,9 @@ fn test_x_removes_characters_on_single_line_document() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("This is a single line document that happens to be quite long.")
 
@@ -210,9 +210,9 @@ fn test_x_removes_from_cursor_then_move_cursor_left_one() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("0000000011111111222222223333333344444444")
 
@@ -234,9 +234,9 @@ fn test_x_removes_from_cursor_on_line_with_single_char_then_move_cursor_right_on
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("012")
 
@@ -255,16 +255,15 @@ fn test_x_removes_from_cursor_on_line_with_single_char_then_move_cursor_right_on
 	assert fake_view.cursor.pos.y == 0
 }
 
-
 fn test_x_removes_from_cursor_then_move_cursor_right_one() {
 	mut clip := clipboardv2.new()
 	mut fake_view := View{
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("0000000011111111222222223333333344444444")
 
@@ -290,9 +289,9 @@ fn test_x_removes_from_cursor_to_end_of_line_and_beyond() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("0000000011111111222222223333333344444444")
 
@@ -332,9 +331,9 @@ fn test_x_does_not_remove_characters_on_multi_line_document_if_at_line_end() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("1. first line\n2. second line\n3. third line")
 
@@ -357,9 +356,9 @@ fn test_x_removes_characters_up_to_end_of_line() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("1. first line\n2. second line\n3. third line")
 
@@ -382,9 +381,9 @@ fn test_w_moves_to_start_of_next_word() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("This is the first line.\n2. second line")
 
@@ -403,9 +402,9 @@ fn test_w_moves_to_start_of_next_line_if_on_empty_line() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("This is the first line.\n\n2. second line")
 
@@ -427,9 +426,9 @@ fn test_w_moves_from_blank_line_to_next() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("\n\n\n\n\n")
 
@@ -463,9 +462,9 @@ fn test_w_moves_from_end_line_to_blank_next_line() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("T\n\nX\n")
 
@@ -487,9 +486,9 @@ fn test_w_moves_from_end_of_word_to_start_of_next() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("First      Word")
 
@@ -511,9 +510,9 @@ fn test_w_moves_to_start_of_next_word_across_a_newline() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("This is the first line.\n2. second line")
 
@@ -538,9 +537,9 @@ fn test_w_moves_to_start_of_next_word_up_to_document_end() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("This is the first line.\n2. second line")
 
@@ -558,9 +557,9 @@ fn test_w_moves_to_start_of_next_word_from_whitespace() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("                This is the first line.")
 
@@ -578,9 +577,9 @@ fn test_e_moves_to_end_of_next_word() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("This is a line, the first line.\n2. second line")
 
@@ -607,9 +606,9 @@ fn test_e_moves_from_blank_line_to_next() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("\n\n\n\n\n")
 
@@ -643,9 +642,9 @@ fn test_b_moves_to_start_of_current_word() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("This is a line, the first line.\n2. second line")
 
@@ -667,9 +666,9 @@ fn test_b_moves_to_end_of_previous_line_if_on_empty_line() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("This is the first line.\n2. second line")
 
@@ -688,9 +687,9 @@ fn test_b_moves_from_blank_line_to_next() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("\n\n\n\n\n")
 
@@ -713,9 +712,9 @@ fn test_enter_inserts_newline_at_cursor_in_middle_of_line() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("This is a sentence, it is in fact the first sentence.")
 
@@ -740,9 +739,9 @@ fn test_enter_inserts_newline_at_cursor_in_line_multiple_times() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("This is a sentence, it is in fact the first sentence.")
 
@@ -771,9 +770,9 @@ fn test_enter_inserts_newline_at_cursor_at_start_of_line() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("This is a sentence, it is in fact the first sentence.")
 
@@ -798,9 +797,9 @@ fn test_enter_inserts_newline_at_cursor_at_end_of_line() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("This is a sentence, it is in fact the first sentence.")
 
@@ -825,9 +824,9 @@ fn test_backspace_deletes_character_at_cursor_in_middle_of_line() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("This is a sentence, it is in fact the first sentence.")
 
@@ -861,9 +860,9 @@ fn test_backspace_does_nothing_if_at_start_of_the_line() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("This is a sentence, it is in fact the first sentence.")
 
@@ -887,9 +886,9 @@ fn test_backspace_removing_newlines() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("This is the first sentence.\nThis is the second sentence.")
 
@@ -929,9 +928,9 @@ fn test_left_arrow_at_start_of_sentence() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("\nsingle line of text!\n")
 
@@ -950,9 +949,9 @@ fn test_left_arrow_at_end_of_sentence() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("\nsingle line of text!\n")
 
@@ -971,9 +970,9 @@ fn test_right_arrow_at_start_of_sentence() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("\nsingle line of text!\n")
 
@@ -992,9 +991,9 @@ fn test_right_arrow_at_end_of_sentence() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("\nsingle line of text!\n")
 
@@ -1013,9 +1012,9 @@ fn test_h_at_start_of_sentence() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("\nsingle line of text!\n")
 
@@ -1034,9 +1033,9 @@ fn test_h_at_end_of_sentence() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("\nsingle line of text!\n")
 
@@ -1055,9 +1054,9 @@ fn test_l_at_start_of_sentence() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("\nsingle line of text!\n")
 
@@ -1076,9 +1075,9 @@ fn test_l_at_end_of_sentence() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("\nsingle line of text!\n")
 
@@ -1097,9 +1096,9 @@ fn test_j_at_start_of_sentence() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("\nsingle line of text!\n")
 
@@ -1118,9 +1117,9 @@ fn test_j_in_middle_of_sentence_retain_x_pos_second_line_is_long_enough() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("\nFirst line of multiple lines of text!\nSecond line of multiple")
 
@@ -1139,9 +1138,9 @@ fn test_j_in_middle_of_sentence_does_not_retain_x_pos_second_line_is_too_short()
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("\nFirst line of multiple lines of text!\nSecond")
 
@@ -1160,9 +1159,9 @@ fn test_k_at_start_of_sentence() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("\nsingle line of text!\n")
 
@@ -1181,9 +1180,9 @@ fn test_k_in_middle_of_sentence_retain_x_pos_second_line_is_long_enough() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("\nFirst line of multiple lines of text!\nSecond line of multiple")
 
@@ -1202,9 +1201,9 @@ fn test_k_in_middle_of_sentence_does_not_retain_x_pos_second_line_is_too_short()
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("\nFirst\nSecond line of multiple lines of text!")
 
@@ -1223,9 +1222,9 @@ fn test_jump_cursor_up_to_next_blank_line() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap([
 		"# Top of the file",
@@ -1249,9 +1248,9 @@ fn test_jump_cursor_down_to_next_blank_line() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap([
 		"# Top of the file",
@@ -1278,9 +1277,9 @@ fn test_tab_inserts_a_tab_not_spaces() {
 		config: workspace.Config{
 			insert_tabs_not_spaces: true
 		}
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
 	fake_view.buffer.load_contents_into_gap("1. first line")
 
@@ -1303,10 +1302,11 @@ fn test_tab_inserts_spaces_not_a_tab() {
 		config: workspace.Config{
 			insert_tabs_not_spaces: false
 		}
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
+	// TODO(tauraamui) [13/02/2025]: change this so we stop invoking load_contents_into_gap directly
 	fake_view.buffer.load_contents_into_gap("1. first line")
 
 	fake_view.cursor.pos.x = 9
@@ -1328,10 +1328,11 @@ fn test_find_end_of_line() {
 		config: workspace.Config{
 			insert_tabs_not_spaces: false
 		}
+		buffer: buffer.Buffer.new("", true)
 	}
 
-	fake_view.buffer.use_gap_buffer = true
 	// manually set the "document" contents
+	// TODO(tauraamui) [13/02/2025]: change this so we stop invoking load_contents_into_gap directly
 	fake_view.buffer.load_contents_into_gap("1. first line\n2. second line and slightly longer!")
 
 	fake_view.cursor.pos.x = 0

--- a/src/view_keybinds_test.v
+++ b/src/view_keybinds_test.v
@@ -16,6 +16,7 @@ module main
 
 import lib.clipboardv2
 import lib.draw
+import lib.buffer
 import term.ui as tui
 import log
 
@@ -72,6 +73,7 @@ fn test_view_keybind_key_event_of_value_leader_key_changes_mode_to_leader() {
 		log:       log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 	fake_view.buffer.lines = [] // NOTE(tauraamui) [21/01/25] can be empty just not nil
 
@@ -101,6 +103,7 @@ fn test_view_keybind_leader_then_ff_suffix_opens_file_finder() {
 		log:       log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 	fake_view.buffer.lines = [] // NOTE(tauraamui) [21/01/25] can be empty just not nil
 
@@ -135,6 +138,7 @@ fn test_view_keybind_leader_then_xff_suffix_opens_file_finder_in_special_mode() 
 		log:       log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 	fake_view.buffer.lines = [] // NOTE(tauraamui) [21/01/25] can be empty just not nil
 
@@ -173,6 +177,7 @@ fn test_view_keybind_leader_then_fb_suffix_opens_inactive_buffer_finder() {
 		log:       log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 	fake_view.buffer.lines = [] // NOTE(tauraamui) [21/01/25] can be empty just not nil
 
@@ -207,6 +212,7 @@ fn test_view_keybind_leader_then_ftc_suffix_opens_todo_comments_finder() {
 		log:       log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 	fake_view.buffer.lines = [] // NOTE(tauraamui) [21/01/25] can be empty just not nil
 
@@ -497,6 +503,7 @@ fn test_sets_of_key_events_for_views_on_key_down_adjusting_cursor_position() {
 			log:       log.Log{}
 			leader_state: ViewLeaderState{ mode: .normal }
 			clipboard: mut clip
+			buffer: buffer.Buffer.new("", false)
 		}
 		fake_view.buffer.lines = case.document_contents
 		fake_view.cursor.pos = case.starting_cursor_pos
@@ -524,6 +531,7 @@ fn test_w_moves_cursor_to_next_line_with_plain_comments() {
 		log:       log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 	fake_view.buffer.lines = fake_lines
 	fake_view.cursor.pos = Pos{

--- a/src/view_test.v
+++ b/src/view_test.v
@@ -18,6 +18,7 @@ import arrays
 import lib.clipboardv2
 import lib.workspace
 import lib.chords
+import lib.buffer
 import json
 import lib.draw
 import term.ui as tui
@@ -77,6 +78,7 @@ fn test_dd_deletes_current_line_at_start_of_doc() {
 		log:       log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 	fake_view.buffer.lines = ['1. first line', '2. second line', '3. third line', '4. fourth line']
 	fake_view.cursor.pos.y = 0
@@ -94,6 +96,7 @@ fn test_dd_deletes_current_line_in_middle_of_doc() {
 		log:       log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 	fake_view.buffer.lines = ['1. first line', '2. second line', '3. third line', '4. fourth line']
 	fake_view.cursor.pos.y = 2
@@ -112,6 +115,7 @@ fn test_dd_deletes_current_line_at_end_of_doc() {
 		log:       log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 	// manually set the "document" contents
 	fake_view.buffer.lines = ['1. first line', '2. second line', '3. third line']
@@ -133,6 +137,7 @@ fn test_dd_deletes_current_line_and_p_reinserts_it_correctly() {
 		log:       log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 	fake_view.buffer.lines = ['1. first line', '2. second line', '3. third line', '4. forth line']
 	fake_view.cursor.pos.y = 0
@@ -160,6 +165,7 @@ fn test_visual_line_select_delete_and_paste_works_correctly() {
 		log:      log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 	fake_view.buffer.lines = ['1. first line', '2. second line', '3. third line', '4. fourth line']
 	fake_view.j()
@@ -183,6 +189,7 @@ fn test_visual_select_copy_and_paste_works_correctly() {
 		log:       log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 	fake_view.buffer.lines = ['This is kind of a mega line right? It is pretty long!', '2. second line', '3. third line', '4. fourth line']
 
@@ -226,6 +233,7 @@ fn test_visual_select_across_multiple_lines_copy_and_paste_works_correctly() {
 		log:       log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 	fake_view.buffer.lines = ['This is kind of a mega line right? It is pretty long!', '2. second line', '3. third line', '4. fourth line']
 
@@ -264,6 +272,7 @@ fn test_insert_text() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 	// manually set the "document" contents
 	fake_view.buffer.lines = ['1. first line', '2. second line']
@@ -284,6 +293,7 @@ fn test_o_inserts_sentance_line() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 	// manually set the "document" contents
 	fake_view.buffer.lines = ['1. first line', '2. second line']
@@ -304,6 +314,7 @@ fn test_o_inserts_sentance_line_end_of_document() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 	// manually set the "document" contents
 	fake_view.buffer.lines = ['1. first line', '2. second line']
@@ -324,6 +335,7 @@ fn test_o_inserts_line_and_auto_indents() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 	// manually set the "document" contents
 	fake_view.buffer.lines = ['	1. first line']
@@ -344,6 +356,7 @@ fn test_o_auto_indents_but_clears_if_nothing_added_to_line() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 	// manually set the "document" contents
 	fake_view.buffer.lines = ['	1. first line']
@@ -391,6 +404,7 @@ fn test_v_toggles_visual_mode_and_starts_selection() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 	// manually set the "document" contents
 	fake_view.buffer.lines = ['1. first line']
@@ -420,6 +434,7 @@ fn test_v_toggles_visual_mode_move_selection_down_to_second_line_ensure_start_po
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 	// manually set the "document" contents
 	fake_view.buffer.lines = ['1. first line', '//']
@@ -463,6 +478,7 @@ fn test_shift_v_toggles_visual_line_mode_and_starts_selection() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 	// manually set the "document" contents
 	fake_view.buffer.lines = ['1. first line']
@@ -696,6 +712,7 @@ fn test_enter_from_start_of_line() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .insert }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 	// manually set the "document" contents
 	fake_view.buffer.lines = [
@@ -720,6 +737,7 @@ fn test_enter_moves_trailing_segment_to_next_line_and_moves_cursor_in_front() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .insert }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 	// manually set the "document" contents
 	fake_view.buffer.lines = [
@@ -744,6 +762,7 @@ fn test_enter_moves_trailing_segment_to_next_line_and_moves_cursor_to_past_prefi
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .insert }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 	fake_view.buffer.lines = [
 		'    1. first line with whitespace prefix',
@@ -767,6 +786,7 @@ fn test_enter_inserts_line_at_cur_pos_and_auto_indents() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .insert }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 	// manually set the "document" contents
 	fake_view.buffer.lines = ['	indented first line']
@@ -787,6 +807,7 @@ fn test_enter_auto_indents_but_clears_if_nothing_added_to_line() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .insert }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 	// manually set the "document" contents
 	fake_view.buffer.lines = ['	indented first line']
@@ -809,6 +830,7 @@ fn test_backspace_deletes_char_from_end_of_sentance() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 	// manually set the "document" contents
 	fake_view.buffer.lines = ['single line of text!']
@@ -832,6 +854,7 @@ fn test_backspace_deletes_char_from_start_of_sentance() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 	fake_view.leader_state.mode = .insert
 
@@ -853,6 +876,7 @@ fn test_backspace_moves_line_up_to_previous_line() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 	fake_view.leader_state.mode = .insert
 
@@ -874,6 +898,7 @@ fn test_backspace_moves_line_up_to_end_of_previous_line() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 	fake_view.leader_state.mode = .insert
 
@@ -898,6 +923,7 @@ fn test_backspace_at_start_of_sentance_first_line_does_nothing() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 	fake_view.leader_state.mode = .insert
 
@@ -918,6 +944,7 @@ fn test_move_cursor_left_with_h_proceeds_to_start_of_line() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: clipboardv2.new()
+		buffer: buffer.Buffer.new("", false)
 	}
 	fake_view.buffer.lines = ['1. first line']
 
@@ -952,6 +979,7 @@ fn test_move_cursor_right_with_l_proceeds_to_end_of_line() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: clipboardv2.new()
+		buffer: buffer.Buffer.new("", false)
 	}
 	fake_view.buffer.lines = ['1. first line']
 
@@ -985,6 +1013,7 @@ fn test_move_cursor_down_with_j_proceeds_to_next_line_with_x_maxed() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: clipboardv2.new()
+		buffer: buffer.Buffer.new("", false)
 	}
 	fake_view.buffer.lines = [
 		'1. first line with five words',
@@ -1024,6 +1053,7 @@ fn test_move_cursor_up_with_k_proceeds_to_previous_line_with_x_maxed() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: clipboardv2.new()
+		buffer: buffer.Buffer.new("", false)
 	}
 	fake_view.buffer.lines = [
 		'1. first line with five words',
@@ -1063,6 +1093,7 @@ fn test_move_cursor_left_with_left_proceeds_to_start_of_line() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: clipboardv2.new()
+		buffer: buffer.Buffer.new("", false)
 	}
 	fake_view.buffer.lines = ['1. first line']
 
@@ -1097,6 +1128,7 @@ fn test_move_cursor_right_with_right_proceeds_to_end_of_line() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: clipboardv2.new()
+		buffer: buffer.Buffer.new("", false)
 	}
 	fake_view.buffer.lines = ['1. first line']
 
@@ -1130,6 +1162,7 @@ fn test_move_cursor_down_with_down_proceeds_to_next_line_with_x_maxed() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: clipboardv2.new()
+		buffer: buffer.Buffer.new("", false)
 	}
 	fake_view.buffer.lines = [
 		'1. first line with five words',
@@ -1169,6 +1202,7 @@ fn test_move_cursor_down_with_down_proceeds_to_next_line_with_x_maxed_contains_b
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: clipboardv2.new()
+		buffer: buffer.Buffer.new("", false)
 	}
 	fake_view.buffer.lines = [
 		'1. first line with five words',
@@ -1208,6 +1242,7 @@ fn test_move_cursor_up_with_up_proceeds_to_previous_line_with_x_maxed() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: clipboardv2.new()
+		buffer: buffer.Buffer.new("", false)
 	}
 	fake_view.buffer.lines = [
 		'1. first line with five words',
@@ -1247,6 +1282,7 @@ fn test_move_cursor_up_with_up_proceeds_to_next_line_with_x_maxed_contains_blank
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: clipboardv2.new()
+		buffer: buffer.Buffer.new("", false)
 	}
 	fake_view.buffer.lines = [
 		'1. first line with five words',
@@ -1287,6 +1323,7 @@ fn test_left_arrow_at_start_of_sentence_in_insert_mode() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 	fake_view.leader_state.mode = .insert
 
@@ -1310,6 +1347,7 @@ fn test_left_arrow_at_end_of_sentence_in_insert_mode() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 	fake_view.leader_state.mode = .insert
 
@@ -1332,6 +1370,7 @@ fn test_right_arrow_at_start_of_sentence_in_insert_mode() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 	fake_view.leader_state.mode = .insert
 
@@ -1354,6 +1393,7 @@ fn test_right_arrow_at_end_of_sentence_in_insert_mode() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 	fake_view.leader_state.mode = .insert
 
@@ -1376,6 +1416,7 @@ fn test_right_arrow_on_empty_line_in_normal_mode() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 	// fake_view.leader_state.mode = .insert
 
@@ -1398,6 +1439,7 @@ fn test_tab_inserts_spaces() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .insert }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 
 	// manually set the documents contents
@@ -1424,6 +1466,7 @@ fn test_tab_inserts_tabs_not_spaces_if_enabled() {
 		config:    workspace.Config{
 			insert_tabs_not_spaces: true
 		}
+		buffer: buffer.Buffer.new("", false)
 	}
 
 	// manually set the documents contents
@@ -1449,6 +1492,7 @@ fn test_visual_indent_indents_highlighted_lines() {
 		config:    workspace.Config{
 			insert_tabs_not_spaces: true
 		}
+		buffer: buffer.Buffer.new("", false)
 	}
 
 	fake_view.buffer.lines = [
@@ -1487,6 +1531,7 @@ fn test_visual_unindent_unindents_highlighted_lines() {
 		config:    workspace.Config{
 			insert_tabs_not_spaces: true
 		}
+		buffer: buffer.Buffer.new("", false)
 	}
 
 	fake_view.buffer.lines = [
@@ -1523,6 +1568,7 @@ fn test_visual_insert_mode_and_delete_in_place() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 
 	// manually set the documents contents
@@ -1544,6 +1590,7 @@ fn test_visual_insert_mode_selection_move_down_once_and_delete() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 
 	// manually set the documents contents
@@ -1566,6 +1613,7 @@ fn test_visual_selection_copy_starts_and_ends_on_same_line_and_selects_whole_lin
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 
 	// manually set the documents contents
@@ -1597,6 +1645,7 @@ fn test_visual_selection_mode_escaped_leaves_cursor_in_final_position() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 
 	// manually set the documents contents
@@ -1626,6 +1675,7 @@ fn test_visual_selection_copy_ends_on_halfway_in_on_next_line_down() {
 		log:       unsafe { nil }
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 
 	// manually set the documents contents
@@ -1656,6 +1706,7 @@ fn test_visual_selection_copy_starts_and_ends_a_few_lines_down() {
 		log:       unsafe { nil }
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 
 	// manually set the documents contents
@@ -1686,6 +1737,7 @@ fn test_visual_line_selection_copy() {
 		log:       unsafe { nil }
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 
 	// manually set the documents contents
@@ -1723,6 +1775,7 @@ fn test_paste_segment_of_line() {
 		log:       unsafe { nil }
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 
 	// manually set the documents contents
@@ -1754,6 +1807,7 @@ fn test_paste_segment_which_does_not_start_nor_end_with_newline() {
 		log:       unsafe { nil }
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 
 	// manually set the documents contents
@@ -1790,6 +1844,7 @@ fn test_paste_full_lines() {
 		log:       unsafe { nil }
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 
 	// manually set the documents contents
@@ -1824,6 +1879,7 @@ fn test_copying_full_lines_with_visual_line_mode_and_pasting() {
 		log:       unsafe { nil }
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 
 	// manually set the documents contents
@@ -1868,6 +1924,7 @@ fn test_search_is_toggled() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 
 	fake_view.search()
@@ -1973,6 +2030,7 @@ fn test_move_cursor_with_b_from_start_of_line_which_preceeds_a_blank_line() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: clipboardv2.new()
+		buffer: buffer.Buffer.new("", false)
 	}
 	fake_view.buffer.lines = ['1. first line', '', '3. third line']
 
@@ -1990,6 +2048,7 @@ fn test_jump_cursor_up_to_next_blank_line() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: clipboardv2.new()
+		buffer: buffer.Buffer.new("", false)
 	}
 	fake_view.buffer.lines = [
 		'# Top of the file',
@@ -2014,6 +2073,7 @@ fn test_jump_cursor_down_to_next_blank_line() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: clipboardv2.new()
+		buffer: buffer.Buffer.new("", false)
 	}
 	fake_view.buffer.lines = [
 		'# Top of the file',
@@ -2040,6 +2100,7 @@ fn test_calc_w_move_end_of_line_jumps_down_to_next_line_which_is_blank() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: clipboardv2.new()
+		buffer: buffer.Buffer.new("", false)
 	}
 	fake_view.buffer.lines = [
 		'# Top of the file',
@@ -2638,6 +2699,7 @@ fn test_a_enters_insert_mode_after_cursor_position() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 
 	fake_view.buffer.lines = ['single line of text!']
@@ -2656,6 +2718,7 @@ fn test_shift_a_enters_insert_mode_at_the_end_of_current_line() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 
 	fake_view.buffer.lines = ['some line of text', 'single line of text!', 'a third line!']
@@ -2683,6 +2746,7 @@ fn test_r_replaces_character_in_middle_of_line() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 
 	fake_view.buffer.lines = ['some random line', 'another line of text', 'one last line']
@@ -2717,6 +2781,7 @@ fn test_r_replaces_character_with_special_character() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 
 	fake_view.buffer.lines = ['some random line', 'another line of text', 'one last line']
@@ -2751,6 +2816,7 @@ fn test_r_replaces_character_with_space() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 
 	fake_view.buffer.lines = ['some random line', 'another line of text', 'one last line']
@@ -2785,6 +2851,7 @@ fn test_r_doesnt_change_anything_when_escape_is_used() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 
 	fake_view.buffer.lines = ['some random line', 'another line of text', 'one last line']
@@ -2818,6 +2885,7 @@ fn test_r_doesnt_change_anything_when_enter_is_used() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 
 	fake_view.buffer.lines = ['some random line', 'another line of text', 'one last line']
@@ -2845,6 +2913,7 @@ fn test_shift_o_adds_line_above_cursor() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 
 	fake_view.buffer.lines = ['some line of text', 'another line of text']
@@ -2866,6 +2935,7 @@ fn test_shift_o_adds_line_above_cursor_at_start_of_file() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 
 	fake_view.buffer.lines = ['some line of text', 'another line of text']
@@ -2888,6 +2958,7 @@ fn test_x_removes_character_in_middle_of_line() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 
 	fake_view.buffer.lines = ['this is a lines of text']
@@ -2908,6 +2979,7 @@ fn test_x_removes_character_and_shifts_cursor_back_at_end_of_line() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 
 	fake_view.buffer.lines = ['this is a lines of text']
@@ -2952,6 +3024,7 @@ fn test_auto_closing_square_brace() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 
 	fake_view.buffer.lines = ['']
@@ -2983,6 +3056,7 @@ fn test_auto_closing_curley_brace() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 
 	fake_view.buffer.lines = ['']
@@ -3014,6 +3088,7 @@ fn test_auto_closing_curley_brace_inputting_secondary_close_should_only_move_cur
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 
 	fake_view.buffer.lines = ['']
@@ -3054,6 +3129,7 @@ fn test_auto_closing_square_brace_inputting_secondary_close_should_only_move_cur
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 
 	fake_view.buffer.lines = ['']
@@ -3087,6 +3163,7 @@ fn test_search_line_correct_overwrite() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: clipboardv2.new()
+		buffer: buffer.Buffer.new("", false)
 	}
 
 	fake_view.cmd_buf.err_msg = "previously run unrecognised command error message"
@@ -3106,6 +3183,7 @@ fn test_center_text_around_cursor() {
 		log: log.Log{}
         leader_state: ViewLeaderState{ mode: .normal }
         height: 10 // Set a small height for testing
+		buffer: buffer.Buffer.new("", false)
     }
 
     // Create a document with more lines than the view height
@@ -3155,6 +3233,7 @@ fn test_zero_key_handling() {
 	mut fake_view := View{
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
+		buffer: buffer.Buffer.new("", false)
 	}
 
 	fake_view.buffer.lines = ['    This is a test line', 'Another line']
@@ -3185,6 +3264,7 @@ fn test_repeat_command_with_chord_repeat_amount() {
 		log: log.Log{}
         leader_state: ViewLeaderState{ mode: .normal }
         height: 40
+		buffer: buffer.Buffer.new("", false)
     }
 
     // Set initial view bounds
@@ -3239,6 +3319,7 @@ fn test_f_finds_in_current_line_command() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 	fake_view.buffer.lines = ['The quick brown fox jumps over the lazy dog']
 	fake_view.cursor.pos.x = 0
@@ -3261,6 +3342,7 @@ fn test_gg_goes_to_top_of_file_command() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 	fake_view.buffer.lines = ['Line 1', 'Line 2', 'Line 3']
 	fake_view.cursor.pos.y = 2
@@ -3277,6 +3359,7 @@ fn test_left_square_brace_goes_to_top_of_file() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 	fake_view.buffer.lines = []string{}
 	for i in 0..100 {
@@ -3300,6 +3383,7 @@ fn test_shift_g_goes_to_bottom_of_file_command() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 	fake_view.buffer.lines = ['Line 1', 'Line 2', 'Line 3']
 	fake_view.cursor.pos.y = 2
@@ -3315,6 +3399,7 @@ fn test_right_square_brace_goes_to_top_of_file() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 	fake_view.buffer.lines = []string{}
 	for i in 0..100 {
@@ -3341,6 +3426,7 @@ fn test_shift_r_replaces_character_in_line_command() {
 		log: log.Log{}
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
+		buffer: buffer.Buffer.new("", false)
 	}
 	fake_view.buffer.lines = ['The quick brown fox']
 	fake_view.cursor.pos.x = 2
@@ -3364,6 +3450,7 @@ fn test_shift_l_goes_to_lowest_part_of_view_command() {
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
 		height: 10
+		buffer: buffer.Buffer.new("", false)
 	}
 	fake_view.buffer.lines = ['Line 1', 'Line 2', 'Line 3', 'Line 4', 'Line 5', 'Line 6', 'Line 7', 'Line 8', 'Line 9', 'Line 10']
 	fake_view.from = 0
@@ -3381,6 +3468,7 @@ fn test_shift_m_goes_to_middle_part_of_view_command() {
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
 		height: 10
+		buffer: buffer.Buffer.new("", false)
 	}
 	fake_view.buffer.lines = ['Line 1', 'Line 2', 'Line 3', 'Line 4', 'Line 5', 'Line 6', 'Line 7', 'Line 8', 'Line 9', 'Line 10']
 	fake_view.from = 0
@@ -3398,6 +3486,7 @@ fn test_shift_h_goes_to_highest_part_of_view_command() {
 		leader_state: ViewLeaderState{ mode: .normal }
 		clipboard: mut clip
 		height: 10
+		buffer: buffer.Buffer.new("", false)
 	}
 	fake_view.buffer.lines = ['Line 1', 'Line 2', 'Line 3', 'Line 4', 'Line 5', 'Line 6', 'Line 7', 'Line 8', 'Line 9', 'Line 10']
 	fake_view.from = 0


### PR DESCRIPTION
This change doesn't change the underlying implementation of instantiating or storing views and buffers as of yet, but it does provide a parallel and *working* alternative which is arguably superior. Lookups for existing buffer and view instances for any given file path will soon be constant time.