### PR TITLE
Fix/buffer view wrapping long lines

### DIFF
--- a/src/lib/ui/buffer_view.v
+++ b/src/lib/ui/buffer_view.v
@@ -72,6 +72,10 @@ fn draw_text_line(mut ctx draw.Contextable, x int, y int, line string, min_x int
 
 	mut line_past_min_x := linex.runes()[min_x..].string()
 
+	if line_past_min_x.runes().len > width - x {
+		line_past_min_x = line_past_min_x.runes()[..(width - x)].string()
+	}
+
 	ctx.draw_text(x, y, line_past_min_x)
 }
 

--- a/src/lib/ui/buffer_view.v
+++ b/src/lib/ui/buffer_view.v
@@ -67,7 +67,10 @@ fn draw_line_number(mut ctx draw.Contextable, x int, y int, line_num int) {
 fn draw_text_line(mut ctx draw.Contextable, x int, y int, line string, min_x int, width int) {
 	if min_x >= line.runes().len { ctx.draw_text(x, y, ""); return }
 
-	line_past_min_x := line.runes()[min_x..].string()
+	mut line_past_min_x := line.runes()[min_x..].string()
+	if line_past_min_x.len > (width - x) {
+		line_past_min_x = line_past_min_x[..(width - x)]
+	}
 
 	ctx.draw_text(x, y, line_past_min_x)
 }

--- a/src/lib/ui/buffer_view_test.v
+++ b/src/lib/ui/buffer_view_test.v
@@ -39,9 +39,10 @@ fn test_buffer_view_draws_lines_0_to_max_height() {
 	y := 0
 	width := 100
 	height := 10
+	min_x := 0
 	from_line_num := 0
 
-	buf_view.draw(mut mock_ctx, x, y, width, height, from_line_num, 0)
+	buf_view.draw(mut mock_ctx, x, y, width, height, from_line_num, min_x, 0)
 
 	assert drawn_text == [
 		DrawnText{ x: 2, y: 1, data:  "1" },
@@ -83,9 +84,10 @@ fn test_buffer_view_draws_lines_10_to_max_height() {
 	y := 0
 	width := 100
 	height := 10
+	min_x := 0
 	from_line_num := 10
 
-	buf_view.draw(mut mock_ctx, x, y, width, height, from_line_num, 0)
+	buf_view.draw(mut mock_ctx, x, y, width, height, from_line_num, min_x, 0)
 
 	assert drawn_text == [
 		DrawnText{ x: 1, y: 1, data:  "11" },
@@ -122,15 +124,15 @@ fn test_buffer_view_draws_lines_0_to_max_height_min_x_is_6() {
 	mut buf      := buffer.Buffer.new("", false)
 	for i in 0..20 { buf.lines << "${i} This is line ${i} in the document" }
 	mut buf_view := BufferView.new(&buf)
-	buf_view.min_x = 6
 
 	x := 0
 	y := 0
 	width := 100
 	height := 10
+	min_x := 6
 	from_line_num := 0
 
-	buf_view.draw(mut mock_ctx, x, y, width, height, from_line_num, 0)
+	buf_view.draw(mut mock_ctx, x, y, width, height, from_line_num, min_x, 0)
 
 	assert drawn_text == [
 		DrawnText{ x: 2, y: 1, data: "1" }
@@ -153,6 +155,51 @@ fn test_buffer_view_draws_lines_0_to_max_height_min_x_is_6() {
 		DrawnText{ x: 4, y: 9, data:  " is line 8 in the document" },
 		DrawnText{ x: 1, y: 10, data: "10" }
 		DrawnText{ x: 4, y: 10, data: " is line 9 in the document" }
+	]
+}
+
+fn test_buffer_view_draws_lines_0_to_max_height_min_x_0_max_width_8() {
+	mut drawn_text := []DrawnText{}
+	mut ref := &drawn_text
+	mut mock_ctx := MockContextable{
+		on_draw_cb: fn [mut ref] (x int, y int, text string) {
+			ref << DrawnText{ x: x, y: y, data: text }
+		}
+	}
+	mut buf      := buffer.Buffer.new("", false)
+	for i in 0..20 { buf.lines << "${i} This is line ${i} in the document" }
+	mut buf_view := BufferView.new(&buf)
+
+	x := 0
+	y := 0
+	width := 8
+	height := 10
+	min_x := 0
+	from_line_num := 0
+
+	buf_view.draw(mut mock_ctx, x, y, width, height, from_line_num, min_x, 0)
+
+	assert drawn_text == [
+		DrawnText{ x: 2, y: 1, data: "1" }
+		DrawnText{ x: 4, y: 1, data:  "0 This is line 0 in the document" },
+		DrawnText{ x: 2, y: 2, data: "2" }
+		DrawnText{ x: 4, y: 2, data:  "1 This is line 1 in the document" },
+		DrawnText{ x: 2, y: 3, data: "3" }
+		DrawnText{ x: 4, y: 3, data:  "2 This is line 2 in the document" },
+		DrawnText{ x: 2, y: 4, data: "4" }
+		DrawnText{ x: 4, y: 4, data:  "3 This is line 3 in the document" },
+		DrawnText{ x: 2, y: 5, data: "5" }
+		DrawnText{ x: 4, y: 5, data:  "4 This is line 4 in the document" },
+		DrawnText{ x: 2, y: 6, data: "6" }
+		DrawnText{ x: 4, y: 6, data:  "5 This is line 5 in the document" },
+		DrawnText{ x: 2, y: 7, data: "7" }
+		DrawnText{ x: 4, y: 7, data:  "6 This is line 6 in the document" },
+		DrawnText{ x: 2, y: 8, data: "8" }
+		DrawnText{ x: 4, y: 8, data:  "7 This is line 7 in the document" },
+		DrawnText{ x: 2, y: 9, data: "9" }
+		DrawnText{ x: 4, y: 9, data:  "8 This is line 8 in the document" },
+		DrawnText{ x: 1, y: 10, data: "10" }
+		DrawnText{ x: 4, y: 10, data: "9 This is line 9 in the document" }
 	]
 }
 

--- a/src/lib/ui/buffer_view_test.v
+++ b/src/lib/ui/buffer_view_test.v
@@ -181,25 +181,25 @@ fn test_buffer_view_draws_lines_0_to_max_height_min_x_0_max_width_12() {
 
 	assert drawn_text == [
 		DrawnText{ x: 2, y: 1, data: "1" }
-		DrawnText{ x: 4, y: 1, data:  "0 This is line 0 in the document" },
+		DrawnText{ x: 4, y: 1, data:  "0 This i" },
 		DrawnText{ x: 2, y: 2, data: "2" }
-		DrawnText{ x: 4, y: 2, data:  "1 This is line 1 in the document" },
+		DrawnText{ x: 4, y: 2, data:  "1 This i" },
 		DrawnText{ x: 2, y: 3, data: "3" }
-		DrawnText{ x: 4, y: 3, data:  "2 This is line 2 in the document" },
+		DrawnText{ x: 4, y: 3, data:  "2 This i" },
 		DrawnText{ x: 2, y: 4, data: "4" }
-		DrawnText{ x: 4, y: 4, data:  "3 This is line 3 in the document" },
+		DrawnText{ x: 4, y: 4, data:  "3 This i" },
 		DrawnText{ x: 2, y: 5, data: "5" }
-		DrawnText{ x: 4, y: 5, data:  "4 This is line 4 in the document" },
+		DrawnText{ x: 4, y: 5, data:  "4 This i" },
 		DrawnText{ x: 2, y: 6, data: "6" }
-		DrawnText{ x: 4, y: 6, data:  "5 This is line 5 in the document" },
+		DrawnText{ x: 4, y: 6, data:  "5 This i" },
 		DrawnText{ x: 2, y: 7, data: "7" }
-		DrawnText{ x: 4, y: 7, data:  "6 This is line 6 in the document" },
+		DrawnText{ x: 4, y: 7, data:  "6 This i" },
 		DrawnText{ x: 2, y: 8, data: "8" }
-		DrawnText{ x: 4, y: 8, data:  "7 This is line 7 in the document" },
+		DrawnText{ x: 4, y: 8, data:  "7 This i" },
 		DrawnText{ x: 2, y: 9, data: "9" }
-		DrawnText{ x: 4, y: 9, data:  "8 This is line 8 in the document" },
+		DrawnText{ x: 4, y: 9, data:  "8 This i" },
 		DrawnText{ x: 1, y: 10, data: "10" }
-		DrawnText{ x: 4, y: 10, data: "9 This is line 9 in the document" }
+		DrawnText{ x: 4, y: 10, data: "9 This i" }
 	]
 }
 

--- a/src/lib/ui/buffer_view_test.v
+++ b/src/lib/ui/buffer_view_test.v
@@ -172,7 +172,7 @@ fn test_buffer_view_draws_lines_0_to_max_height_min_x_0_max_width_8() {
 
 	x := 0
 	y := 0
-	width := 8
+	width := 12
 	height := 10
 	min_x := 0
 	from_line_num := 0

--- a/src/lib/ui/buffer_view_test.v
+++ b/src/lib/ui/buffer_view_test.v
@@ -158,7 +158,7 @@ fn test_buffer_view_draws_lines_0_to_max_height_min_x_is_6() {
 	]
 }
 
-fn test_buffer_view_draws_lines_0_to_max_height_min_x_0_max_width_8() {
+fn test_buffer_view_draws_lines_0_to_max_height_min_x_0_max_width_12() {
 	mut drawn_text := []DrawnText{}
 	mut ref := &drawn_text
 	mut mock_ctx := MockContextable{

--- a/src/view.v
+++ b/src/view.v
@@ -604,7 +604,7 @@ fn (mut view View) draw_x(mut ctx draw.Contextable) {
 					 // the given height it is told to work within, but if we don't call it, the
 					 // cursor won't move, so... *sniff sniff*, smells like toxic tech debt, yayyyy!
 	view.buf_view.draw(
-		mut ctx, 0, 0, ctx.window_width(), ctx.window_height() - 2, view.from, view.cursor.pos.y
+		mut ctx, 0, 0, ctx.window_width(), ctx.window_height() - 2, view.from, 0, view.cursor.pos.y
 	)
 	// view.buf_view.draw(mut ctx, ctx.window_width() / 2, 0, ctx.window_width() / 2, ctx.window_height() - 2, 1000)
 
@@ -629,10 +629,10 @@ fn (mut view View) draw_x(mut ctx draw.Contextable) {
 }
 
 fn (mut view View) draw(mut ctx draw.Contextable) {
-	// view.draw_x(mut ctx)
 	view.offset_x_and_width_by_len_of_longest_line_number_str(ctx.window_width(), ctx.window_height())
 
 	view.update_to()
+	// view.draw_x(mut ctx)
 	view.draw_document(mut ctx)
 
 	ui.draw_status_line(


### PR DESCRIPTION
Should ideally have more test cases for this, because OOB panics etc., but good enough for now. SHIP IT!! This isn't technically a fix, because the UI element we're adding this "fix" to isn't the main code/buffer view implementation being used, it's the new one.