### PR TITLE
fix: adjust fps rate to 30 instead of 60

### DIFF
--- a/src/lib/draw/tui_notd_gui.v
+++ b/src/lib/draw/tui_notd_gui.v
@@ -35,6 +35,7 @@ pub fn new_context(cfg Config) (&Contextable, Runner) {
 			frame_fn:             cfg.frame_fn
 			capture_events:       cfg.capture_events
 			use_alternate_buffer: cfg.use_alternate_buffer
+			frame_rate: 30
 		)
 	}
 	return ctx, unsafe { ctx.run }


### PR DESCRIPTION
this kind of improves the current flickering/perf situation relating to the new buffer view/renderer causing flickering due to the fairly large increase in segment render calls