### PR TITLE
Experiment/emoji grid

### DIFF
--- a/experiment/tui_render/emoji_grid.v
+++ b/experiment/tui_render/emoji_grid.v
@@ -47,7 +47,7 @@ fn (mut grid EmojiGrid) draw_emojis(mut ctx draw.Contextable) {
 
 fn (mut grid EmojiGrid) draw(mut ctx draw.Contextable) {
 	if grid.run_once { return }
-	// defer { grid.run_once = true }
+	defer { grid.run_once = true }
 	grid.update_bounds(ctx.window_width(), ctx.window_height())
 	ctx.clear()
 	// grid.draw_chars(mut ctx)
@@ -62,10 +62,6 @@ fn (grid EmojiGrid) on_key_down(e draw.Event, mut root Root) {
 		}
 		else {}
 	}
-}
-
-interface Root {
-	quit() !
 }
 
 struct App {

--- a/experiment/tui_render/emoji_grid.v
+++ b/experiment/tui_render/emoji_grid.v
@@ -38,8 +38,11 @@ fn (mut grid EmojiGrid) draw_emojis(mut ctx draw.Contextable) {
 	for y in 0..grid.height {
 		// NOTE(tauraamui) [25/04/2025]: utf8 chars take up 2 grid cells not one
 		for x in 0..(grid.width / 2) {
-			rand.seed([u32(x), y])
-			emoji := emoji_chars[rand.int_in_range(0, emoji_chars.len) or { 0 }]
+			mut index := rand.int_in_range(0, emoji_chars.len) or { 0 }
+			if (y - 4 <= 0 || y + 5 >= grid.height) || (x - 15 <= 0 || x + 15 >= (grid.width / 2)) {
+				index = 3
+			}
+			emoji := emoji_chars[index]
 			ctx.draw_text((x * 2) + 1, y + 1, emoji)
 		}
 	}
@@ -47,11 +50,13 @@ fn (mut grid EmojiGrid) draw_emojis(mut ctx draw.Contextable) {
 
 fn (mut grid EmojiGrid) draw(mut ctx draw.Contextable) {
 	if grid.run_once { return }
-	defer { grid.run_once = true }
+	// defer { grid.run_once = true }
 	grid.update_bounds(ctx.window_width(), ctx.window_height())
-	ctx.clear()
+	// ctx.clear()
 	// grid.draw_chars(mut ctx)
+	ctx.hide_cursor()
 	grid.draw_emojis(mut ctx)
+	ctx.show_cursor()
 	ctx.flush()
 }
 

--- a/experiment/tui_render/emoji_grid.v
+++ b/experiment/tui_render/emoji_grid.v
@@ -55,13 +55,17 @@ fn (mut grid EmojiGrid) draw(mut ctx draw.Contextable) {
 	ctx.flush()
 }
 
-fn (grid EmojiGrid) on_key_down(e draw.Event, mut root Root) {
+fn (grid EmojiGrid) on_key_down(e draw.Event, mut root Root2) {
 	match e.code {
 		.escape {
 			root.quit() or { panic("failed to quit via root: ${err}") }
 		}
 		else {}
 	}
+}
+
+interface Root2 {
+	quit() !
 }
 
 struct App {

--- a/src/lib/draw/ctx.v
+++ b/src/lib/draw/ctx.v
@@ -70,6 +70,8 @@ mut:
 	window_height() int
 
 	set_cursor_position(x int, y int)
+	show_cursor()
+	hide_cursor()
 
 	bold()
 

--- a/src/lib/draw/tui_notd_gui.v
+++ b/src/lib/draw/tui_notd_gui.v
@@ -59,6 +59,14 @@ fn (mut ctx Context) set_cursor_position(x int, y int) {
 	ctx.ref.set_cursor_position(x, y)
 }
 
+fn (mut ctx Context) show_cursor() {
+	ctx.ref.show_cursor()
+}
+
+fn (mut ctx Context) hide_cursor() {
+	ctx.ref.hide_cursor()
+}
+
 fn (mut ctx Context) draw_text(x int, y int, text string) {
 	ctx.ref.draw_text(x, y, text)
 }


### PR DESCRIPTION
As this video indicates, the conclusion of this experiment is basically:

It's stupidly efficient to send individual cell update commands in batch each frame, the main way to avoid flickering is not to avoid updating the whole screen each frame but to NEVER clear the entire screen each frame.

https://github.com/user-attachments/assets/90967d83-c53e-4ae3-b6bb-8ac5540b7fa3

