### PR TITLE
Feat/wrap xclip linux clipboard

### DIFF
--- a/experiment/clipboard/r_x11.c
+++ b/experiment/clipboard/r_x11.c
@@ -1,0 +1,147 @@
+// compile with:
+// gcc x11.c -lX11
+
+#include <X11/Xlib.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <limits.h>
+
+#include <X11/Xatom.h>
+
+int main(void) {
+    Display* display = XOpenDisplay(NULL);
+
+    Window window = XCreateSimpleWindow(display, RootWindow(display, DefaultScreen(display)), 10, 10, 200, 200, 1,
+                                 BlackPixel(display, DefaultScreen(display)), WhitePixel(display, DefaultScreen(display)));
+
+    XSelectInput(display, window, ExposureMask | KeyPressMask);
+
+	const Atom UTF8_STRING = XInternAtom(display, "UTF8_STRING", True);
+	const Atom CLIPBOARD = XInternAtom(display, "CLIPBOARD", 0);
+	const Atom XSEL_DATA = XInternAtom(display, "XSEL_DATA", 0);
+
+	const Atom SAVE_TARGETS = XInternAtom((Display*) display, "SAVE_TARGETS", False);
+	const Atom TARGETS = XInternAtom((Display*) display, "TARGETS", False);
+	const Atom MULTIPLE = XInternAtom((Display*) display, "MULTIPLE", False);
+	const Atom ATOM_PAIR = XInternAtom((Display*) display, "ATOM_PAIR", False);
+	const Atom CLIPBOARD_MANAGER = XInternAtom((Display*) display, "CLIPBOARD_MANAGER", False);
+
+	// input
+	XConvertSelection(display, CLIPBOARD, UTF8_STRING, XSEL_DATA, window, CurrentTime);
+	XSync(display, 0);
+
+	XEvent event;
+	XNextEvent(display, &event);
+
+	if (event.type == SelectionNotify && event.xselection.selection == CLIPBOARD && event.xselection.property != 0) {
+
+		int format;
+		unsigned long N, size;
+		char* data, * s = NULL;
+		Atom target;
+
+		XGetWindowProperty(event.xselection.display, event.xselection.requestor,
+			event.xselection.property, 0L, (~0L), 0, AnyPropertyType, &target,
+			&format, &size, &N, (unsigned char**) &data);
+
+		if (target == UTF8_STRING || target == XA_STRING) {
+			printf("paste: %s\n", data);
+			XFree(data);
+		}
+
+		XDeleteProperty(event.xselection.display, event.xselection.requestor, event.xselection.property);
+	}
+
+	// output
+	char text[] = "new string\0";
+
+	XSetSelectionOwner((Display*) display, CLIPBOARD, (Window) window, CurrentTime);
+
+	XConvertSelection((Display*) display, CLIPBOARD_MANAGER, SAVE_TARGETS, None, (Window) window, CurrentTime);
+
+	Bool running = True;
+	while (running) {
+		XNextEvent(display, &event);
+		if (event.type == SelectionRequest) {
+			const XSelectionRequestEvent* request = &event.xselectionrequest;
+
+			XEvent reply = { SelectionNotify };
+			reply.xselection.property = 0;
+
+			if (request->target == TARGETS) {
+				const Atom targets[] = { TARGETS,
+										MULTIPLE,
+										UTF8_STRING,
+										XA_STRING };
+
+				XChangeProperty(display,
+					request->requestor,
+					request->property,
+					4,
+					32,
+					PropModeReplace,
+					(unsigned char*) targets,
+					sizeof(targets) / sizeof(targets[0]));
+
+				reply.xselection.property = request->property;
+			}
+
+			if (request->target == MULTIPLE) {
+				Atom* targets = NULL;
+
+				Atom actualType = 0;
+				int actualFormat = 0;
+				unsigned long count = 0, bytesAfter = 0;
+
+				XGetWindowProperty(display, request->requestor, request->property, 0, LONG_MAX, False, ATOM_PAIR, &actualType, &actualFormat, &count, &bytesAfter, (unsigned char **) &targets);
+
+				unsigned long i;
+				for (i = 0; i < count; i += 2) {
+					Bool found = False;
+
+					if (targets[i] == UTF8_STRING || targets[i] == XA_STRING) {
+						XChangeProperty((Display*) display,
+							request->requestor,
+							targets[i + 1],
+							targets[i],
+							8,
+							PropModeReplace,
+							(unsigned char*) text,
+							sizeof(text));
+						XFlush(display);
+						running = False;
+					} else {
+						targets[i + 1] = None;
+					}
+				}
+
+				XChangeProperty((Display*) display,
+					request->requestor,
+					request->property,
+					ATOM_PAIR,
+					32,
+					PropModeReplace,
+					(unsigned char*) targets,
+					count);
+
+				XFlush(display);
+				XFree(targets);
+
+				reply.xselection.property = request->property;
+			}
+
+			reply.xselection.display = request->display;
+			reply.xselection.requestor = request->requestor;
+			reply.xselection.selection = request->selection;
+			reply.xselection.target = request->target;
+			reply.xselection.time = request->time;
+
+			XSendEvent((Display*) display, request->requestor, False, 0, &reply);
+			XFlush(display);
+		}
+	}
+
+    XCloseDisplay(display);
+ }
+

--- a/experiment/clipboard/stdlib.v
+++ b/experiment/clipboard/stdlib.v
@@ -1,0 +1,10 @@
+import src.lib.clipboardv3.x11
+
+fn main() {
+	mut s_clip := x11.new_clipboard()
+	defer {
+		s_clip.shutdown_with_persistence()
+	}
+	s_clip.set_text("Some example text for stdlib clipboard copy!")
+}
+

--- a/experiment/clipboard/wrap_pbpaste.v
+++ b/experiment/clipboard/wrap_pbpaste.v
@@ -1,0 +1,60 @@
+import os
+import time
+
+fn set_content() {
+	mut p := os.new_process('/usr/bin/pbcopy')
+	p.set_redirect_stdio()
+	p.run()
+
+	p.stdin_write("text to copy")
+	os.fd_close(p.stdio_fd[0])
+
+	p.close()
+	p.wait()
+	println("ERR: ${p.err}, CODE: ${p.code}")
+}
+
+fn get_content() {
+	mut out := []string{}
+	mut er := []string{}
+	mut rc := 0
+
+	mut p := os.new_process('/usr/bin/pbpaste')
+	p.set_redirect_stdio()
+	p.run()
+
+	for p.is_alive() {
+		if data := p.pipe_read(.stderr) {
+			eprintln('p.pipe_read .stderr, len: ${data.len:4} | data: `${data#[0..10]}`...')
+			er << data
+		}
+		if data := p.pipe_read(.stdout) {
+			eprintln('p.pipe_read .stdout, len: ${data.len:4} | data: `${data#[0..10]}`...')
+			out << data
+		}
+		// avoid a busy loop, by sleeping a bit between each iteration
+		time.sleep(2 * time.millisecond)
+	}
+
+	out << p.stdout_slurp()
+	er << p.stderr_slurp()
+	p.close()
+	p.wait()
+
+	if p.code > 0 {
+		eprintln('----------------------------------------------------------')
+		eprintln('COMMAND: pbcopy')
+		eprintln('STDOUT:\n${out}')
+		eprintln('STDERR:\n${er}')
+		eprintln('----------------------------------------------------------')
+		rc = 1
+	}
+
+	println("${out.join('')}, ${rc}, ${er.join('')}")
+}
+
+fn main() {
+	// set_content()
+	get_content()
+}
+

--- a/experiment/clipboard/wrap_pbpaste.v
+++ b/experiment/clipboard/wrap_pbpaste.v
@@ -6,7 +6,7 @@ fn set_content() {
 	p.set_redirect_stdio()
 	p.run()
 
-	p.stdin_write("text to copy")
+	p.stdin_write("set clipboard to me")
 	os.fd_close(p.stdio_fd[0])
 
 	p.close()

--- a/experiment/clipboard/x11.c
+++ b/experiment/clipboard/x11.c
@@ -1,0 +1,264 @@
+// compile with:
+// gcc x11.c -lX11
+
+#include <X11/Xlib.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <limits.h>
+#include <unistd.h>
+#include <signal.h>
+
+#include <X11/Xatom.h>
+
+// Global variables for signal handling
+static Display* g_display = NULL;
+static Window g_window = 0;
+static Bool g_exit_requested = False;
+
+void signal_handler(int sig) {
+    if (sig == SIGINT || sig == SIGTERM) {
+        g_exit_requested = True;
+        printf("\nExit signal received, transferring clipboard...\n");
+    }
+}
+
+int main(void) {
+    Display* display = XOpenDisplay(NULL);
+    g_display = display;
+ 
+    Window window = XCreateSimpleWindow(display, RootWindow(display, DefaultScreen(display)), 10, 10, 200, 200, 1,
+                                 BlackPixel(display, DefaultScreen(display)), WhitePixel(display, DefaultScreen(display)));
+    g_window = window;
+ 
+    // No KeyPressMask needed for TUI - remove it from event mask
+    XSelectInput(display, window, ExposureMask); 
+
+	const Atom UTF8_STRING = XInternAtom(display, "UTF8_STRING", True);
+	const Atom CLIPBOARD = XInternAtom(display, "CLIPBOARD", 0);
+	const Atom XSEL_DATA = XInternAtom(display, "XSEL_DATA", 0);
+
+	const Atom SAVE_TARGETS = XInternAtom((Display*) display, "SAVE_TARGETS", False);
+	const Atom TARGETS = XInternAtom((Display*) display, "TARGETS", False);
+	const Atom MULTIPLE = XInternAtom((Display*) display, "MULTIPLE", False);
+	const Atom ATOM_PAIR = XInternAtom((Display*) display, "ATOM_PAIR", False);
+	const Atom CLIPBOARD_MANAGER = XInternAtom((Display*) display, "CLIPBOARD_MANAGER", False);
+
+    // Set up signal handlers for graceful exit
+    signal(SIGINT, signal_handler);
+    signal(SIGTERM, signal_handler);
+
+	// input - read current clipboard content
+	XConvertSelection(display, CLIPBOARD, UTF8_STRING, XSEL_DATA, window, CurrentTime);
+	XSync(display, 0);
+
+	XEvent event;
+	
+	// Wait for clipboard read response with timeout
+	Bool got_clipboard = False;
+	int timeout_count = 0;
+	while (!got_clipboard && timeout_count < 100) { // 1 second timeout
+		if (XPending(display) > 0) {
+			XNextEvent(display, &event);
+			if (event.type == SelectionNotify) {
+				got_clipboard = True;
+				break;
+			}
+		} else {
+			usleep(10000); // 10ms
+			timeout_count++;
+		}
+	}
+
+	if (got_clipboard && event.xselection.selection == CLIPBOARD && event.xselection.property != 0) {
+		int format;
+		unsigned long N, size;
+		char* data, * s = NULL;
+		Atom target;
+
+		XGetWindowProperty(event.xselection.display, event.xselection.requestor,
+			event.xselection.property, 0L, (~0L), 0, AnyPropertyType, &target,
+			&format, &size, &N, (unsigned char**) &data);
+
+		if (target == UTF8_STRING || target == XA_STRING) {
+			printf("Current clipboard: %s\n", data);
+			XFree(data);
+		}
+
+		XDeleteProperty(event.xselection.display, event.xselection.requestor, event.xselection.property);
+	} else {
+		printf("No clipboard content or timeout reading clipboard\n");
+	}
+
+	// output - set new clipboard content
+	char text[] = "new string from TUI app";
+	size_t text_len = strlen(text);
+
+	XSetSelectionOwner((Display*) display, CLIPBOARD, (Window) window, CurrentTime);
+
+	// Verify we actually own the selection
+	if (XGetSelectionOwner(display, CLIPBOARD) != window) {
+		printf("Failed to acquire clipboard ownership\n");
+		XCloseDisplay(display);
+		return 1;
+	}
+
+	printf("Set clipboard to: %s\n", text);
+	printf("Clipboard is active. Send SIGINT/SIGTERM or Ctrl+C to exit gracefully.\n");
+	printf("TUI app can call exit or send signal when needed.\n");
+
+	Bool running = True;
+	Bool clipboard_manager_notified = False;
+	Bool waiting_for_manager = False;
+	time_t manager_request_time = 0;
+
+	while (running) {
+		// Check for exit request (from signal or TUI)
+		if (g_exit_requested && !waiting_for_manager) {
+			// Try to notify clipboard manager
+			Window clipboard_manager_window = XGetSelectionOwner(display, CLIPBOARD_MANAGER);
+			
+			if (clipboard_manager_window != None) {
+				printf("Transferring clipboard to manager...\n");
+				
+				// Send SAVE_TARGETS request to clipboard manager
+				XConvertSelection(display, CLIPBOARD_MANAGER, SAVE_TARGETS, None, window, CurrentTime);
+				XFlush(display);
+				waiting_for_manager = True;
+				manager_request_time = time(NULL);
+			} else {
+				printf("No clipboard manager found - clipboard will be lost\n");
+				running = False;
+			}
+		}
+
+		// Check for timeout when waiting for clipboard manager
+		if (waiting_for_manager && (time(NULL) - manager_request_time) > 2) {
+			printf("Clipboard manager timeout - exiting anyway\n");
+			running = False;
+		}
+
+		// Process X11 events
+		if (XPending(display) > 0) {
+			XNextEvent(display, &event);
+			
+			if (event.type == SelectionClear) {
+				printf("Lost clipboard ownership to another application\n");
+				running = False;
+			}
+			else if (event.type == SelectionNotify) {
+				// Response from clipboard manager
+				if (event.xselection.selection == CLIPBOARD_MANAGER) {
+					if (event.xselection.property != None) {
+						printf("Clipboard manager acknowledged transfer\n");
+					} else {
+						printf("Clipboard manager failed to save clipboard\n");
+					}
+					running = False;
+				}
+			}
+			else if (event.type == SelectionRequest) {
+				const XSelectionRequestEvent* request = &event.xselectionrequest;
+
+				XEvent reply = { SelectionNotify };
+				reply.xselection.property = request->property;
+				reply.xselection.display = request->display;
+				reply.xselection.requestor = request->requestor;
+				reply.xselection.selection = request->selection;
+				reply.xselection.target = request->target;
+				reply.xselection.time = request->time;
+
+				Bool handled = True;
+
+				if (request->target == TARGETS) {
+					// Return list of supported formats
+					const Atom targets[] = { TARGETS,
+											MULTIPLE,
+											UTF8_STRING,
+											XA_STRING };
+
+					XChangeProperty(display,
+						request->requestor,
+						request->property,
+						XA_ATOM,
+						32,
+						PropModeReplace,
+						(unsigned char*) targets,
+						sizeof(targets) / sizeof(targets[0]));
+				}
+				else if (request->target == UTF8_STRING || request->target == XA_STRING) {
+					// Return the actual text content
+					XChangeProperty(display,
+						request->requestor,
+						request->property,
+						request->target,
+						8,
+						PropModeReplace,
+						(unsigned char*) text,
+						text_len);
+				}
+				else if (request->target == MULTIPLE) {	
+					Atom* targets = NULL;
+
+					Atom actualType = 0;
+					int actualFormat = 0;
+					unsigned long count = 0, bytesAfter = 0;
+
+					XGetWindowProperty(display, request->requestor, request->property, 0, LONG_MAX, False, ATOM_PAIR, &actualType, &actualFormat, &count, &bytesAfter, (unsigned char **) &targets);
+
+					if (targets && count > 0) {
+						unsigned long i;
+						for (i = 0; i < count; i += 2) {
+							if (targets[i] == UTF8_STRING || targets[i] == XA_STRING) {
+								XChangeProperty((Display*) display,
+									request->requestor,
+									targets[i + 1],
+									targets[i],
+									8,
+									PropModeReplace,
+									(unsigned char*) text,
+									text_len);
+							} else {
+								targets[i + 1] = None;
+							}
+						}
+
+						XChangeProperty((Display*) display,
+							request->requestor,
+							request->property,
+							ATOM_PAIR,
+							32,
+							PropModeReplace,
+							(unsigned char*) targets,
+							count);
+
+						XFree(targets);
+					}
+				}
+				else {
+					// Unsupported target
+					reply.xselection.property = None;
+					handled = False;
+				}
+
+				XSendEvent((Display*) display, request->requestor, False, 0, &reply);
+				XFlush(display);
+
+				if (handled) {
+					printf("Served clipboard request for target: %s\n", 
+						   request->target == UTF8_STRING ? "UTF8_STRING" :
+						   request->target == XA_STRING ? "XA_STRING" :
+						   request->target == TARGETS ? "TARGETS" :
+						   request->target == MULTIPLE ? "MULTIPLE" : "UNKNOWN");
+				}
+			}
+		} else {
+			// No X11 events pending, sleep briefly to avoid busy waiting
+			usleep(10000); // 10ms
+		}
+	}
+
+	printf("Exiting clipboard handler...\n");
+    XCloseDisplay(display);
+    return 0;
+}

--- a/experiment/clipboard/x11.c.v
+++ b/experiment/clipboard/x11.c.v
@@ -1,0 +1,273 @@
+
+#flag -lX11
+
+#include <X11/Xlib.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <limits.h>
+#include <X11/Xatom.h>
+
+@[typedef]
+pub struct C.Display {}
+
+fn (d &C.Display) str() string {
+	return 'C.Display{}'
+}
+
+@[typedef]
+pub struct C.XSelectionEvent {
+mut:
+	type      int
+	display   &C.Display = unsafe { nil }
+	requestor Window
+	selection Atom
+	target    Atom
+	property  Atom
+	time      int
+}
+
+type Window    = u64
+type Atom      = u64
+type EventMask = u64
+
+fn C.XOpenDisplay(name &u8) &C.Display
+
+fn C.XCloseDisplay(d &C.Display)
+
+fn C.XFlush(display &C.Display)
+
+fn C.XNextEvent(display &C.Display, event &C.XEvent)
+
+fn C.XSetSelectionOwner(display &C.Display, atom Atom, window Window, time int)
+
+fn C.XCreateSimpleWindow(
+	d &C.Display, root Window,
+	x int, y int, width u32 height u32,
+	border_width u32, border u64,
+	background u64
+) Window
+
+fn C.XSelectInput(d &C.Display, window Window, EventMask)
+
+fn C.XInternAtom(display &C.Display, atom_name &u8, only_if_exists int) Atom
+
+fn C.XConvertSelection(display &C.Display, selection Atom, target Atom, property Atom, requestor Window, time int) int
+
+fn C.XSync(display &C.Display, discard int) int
+
+fn C.XGetWindowProperty(
+	display &C.Display, window Window,
+	property Atom, long_offset i64, long_length i64,
+	delete int, req_type Atom, actual_type_return &Atom,
+	actual_format_return &int, nitems_return &u64,
+	bytes_after_return &u64, prop_return &&u8
+) int
+
+fn C.XChangeProperty(
+	display &C.Display,
+	window Window,
+	property Atom,
+	typ Atom,
+	format int,
+	mode int,
+	data voidptr,
+	nelements int
+) int
+
+fn C.XSendEvent(display &C.Display, requestor Window, propegate int, mask i64, event &C.XEvent)
+
+fn C.RootWindow(display &C.Display, screen_number int) Window
+
+fn C.XDeleteProperty(display &C.Display, window Window, property Atom) int
+
+fn C.DefaultScreen(display &C.Display) int
+
+fn C.BlackPixel(display &C.Display, screen_number int) u32
+
+fn C.WhitePixel(display &C.Display, screen_number int) u32
+
+fn C.XFree(data voidptr)
+
+@[typedef]
+pub struct C.XSelectionRequestEvent {
+mut:
+	display   &C.Display = unsafe { nil }
+	owner     Window
+	requestor Window
+	selection Atom
+	target    Atom
+	property  Atom
+	time      int
+}
+
+@[typedef]
+pub struct C.XSelectionEvent {
+mut:
+	type      int
+	display   &C.Display = unsafe { nil }
+	requestor Window
+	selection Atom
+	target    Atom
+	property  Atom
+	time      int
+}
+
+@[typedef]
+pub struct C.XSelectionClearEvent {
+mut:
+	window    Window
+	selection Atom
+}
+
+@[typedef]
+pub struct C.XDestroyWindowEvent {
+mut:
+	window Window
+}
+
+@[typedef]
+union C.XEvent {
+mut:
+	type              int
+	xdestroywindow    C.XDestroyWindowEvent
+	xselectionclear   C.XSelectionClearEvent
+	xselectionrequest C.XSelectionRequestEvent
+	xselection        C.XSelectionEvent
+}
+
+fn main() {
+	display := C.XOpenDisplay(C.NULL)
+	defer { C.XCloseDisplay(display) }
+
+	window := C.XCreateSimpleWindow(
+		display, C.RootWindow(display, C.DefaultScreen(display)),
+		10, 10, 200, 200, 1,
+		C.BlackPixel(display, C.DefaultScreen(display)), C.WhitePixel(display, C.DefaultScreen(display))
+	)
+
+	C.XSelectInput(display, window, C.ExposureMask | C.KeyPressMask)
+
+	utf8_string := C.XInternAtom(display, &char("UTF8_STRING".str), 1)
+	clipboard   := C.XInternAtom(display, &char("CLIPBOARD".str), 0)
+	xsel_data   := C.XInternAtom(display, &char("XSEL_DATA".str), 0)
+
+	save_targets      := C.XInternAtom(display, &char("SAVE_TARGETS".str), 0)
+	targets           := C.XInternAtom(display, &char("TARGETS".str), 0)
+	multiple          := C.XInternAtom(display, &char("MULTIPLE".str), 0)
+	atom_pair         := C.XInternAtom(display, &char("ATOM_PAIR".str), 0)
+	clipboard_manager := C.XInternAtom(display, &char("CLIPBOARD_MANAGER".str), 0)
+
+	C.XConvertSelection(display, clipboard, utf8_string, xsel_data, window, C.CurrentTime)
+	C.XSync(display, 0)
+
+	event := C.XEvent{}
+	C.XNextEvent(display, &event)
+
+	xa_string := Atom(31)
+	if unsafe { event.type == C.SelectionNotify && event.xselection.selection == clipboard && event.xselection.property != 0 } {
+		format := 0
+		n      := u64(0)
+		size   := u64(0)
+		data   := &u8(unsafe { nil })
+		target := Atom(0)
+
+		C.XGetWindowProperty(
+			event.xselection.display, event.xselection.requestor,
+			event.xselection.property, 0, 1024, 0, C.AnyPropertyType,
+			&target, &format, &size, &n, &data
+		)
+
+		if target == utf8_string || target == xa_string {
+			println("CURRENT CLIPBOARD CONTENT: ${cstring_to_vstring(data)}")
+			C.XFree(data)
+		}
+
+		C.XDeleteProperty(event.xselection.display, event.xselection.requestor, event.xselection.property)
+	}
+
+	text_to_insert_to_clipboard := "an example string to copy"
+
+	C.XSetSelectionOwner(display, clipboard, window, C.CurrentTime)
+	C.XConvertSelection(display, clipboard_manager, save_targets, C.None, window, C.CurrentTime)
+
+	mut running := true
+	for running {
+		C.XNextEvent(display, &event)
+		if unsafe { event.type == C.SelectionRequest } {
+			request := unsafe { &event.xselectionrequest }
+
+			mut reply   := C.XEvent{ type: C.SelectionNotify }
+			reply.xselection = C.XSelectionEvent{ property: Atom(0) }
+
+			if request.target == targets {
+				target_atoms := [targets, multiple, utf8_string, xa_string]
+				C.XChangeProperty(
+					display,
+					request.requestor, request.property,
+					Atom(4), Atom(32), C.PropModeReplace,
+					target_atoms.data, target_atoms.len / int(sizeof(target_atoms[0]))
+				)
+
+				reply.xselection.property = request.property
+			}
+
+			if request.target == multiple {
+				mut target_atoms := []Atom{}
+
+				actual_type   := Atom(0)
+				actual_format := 0
+				count         := u64(0)
+				bytes_after   := u64(0)
+
+				C.XGetWindowProperty(
+					display, request.requestor, request.property,
+					0, C.LONG_MAX, 0, atom_pair,
+					&actual_type, &actual_format,
+					&count, &bytes_after, target_atoms.data
+				)
+
+				for i := 0; i < count; i += 2 {
+					if target_atoms[i] == utf8_string || target_atoms[i] == xa_string {
+						C.XChangeProperty(
+							display,
+							request.requestor, target_atoms[i + 1],
+							target_atoms[i], Atom(8), C.PropModeReplace,
+							text_to_insert_to_clipboard.str,
+							text_to_insert_to_clipboard.len
+						)
+						C.XFlush(display)
+						running = false
+						continue
+					}
+					target_atoms[i + 1] = C.None
+				}
+
+				C.XChangeProperty(
+					display,
+					request.requestor,
+					request.property,
+					atom_pair,
+					Atom(32),
+					C.PropModeReplace,
+					target_atoms.data,
+					count
+				)
+				C.XFlush(display)
+				C.XFree(voidptr(&target_atoms))
+
+				reply.xselection.property = request.property
+			}
+
+			reply.xselection.display = request.display
+			reply.xselection.requestor = request.requestor
+			reply.xselection.selection = request.selection
+			reply.xselection.target = request.target
+			reply.xselection.time = request.time
+
+			C.XSendEvent(display, request.requestor, 0, 0, voidptr(&reply))
+			C.XFlush(display)
+		}
+	}
+}
+

--- a/make.vsh
+++ b/make.vsh
@@ -22,6 +22,13 @@ context.task(name: "verbose-test", run: |self| system("v -g -stats test ./src"))
 
 // EXPERIMENTS
 context.task(
+	name: "linux-clipboard",
+	run: fn (self build.Task) ! {
+		system("v -g run ./experiment/clipboard/x11.c.v")
+	}
+)
+
+context.task(
 	name: "emoji-grid",
 	depends: ["copy-emoji-grid-code"]
 	run: fn (self build.Task) ! {

--- a/src/lib/clipboardv3/clipboard.v
+++ b/src/lib/clipboardv3/clipboard.v
@@ -22,6 +22,10 @@ pub fn new() Clipboard {
 	$if darwin {
 		return new_darwin_clipboard()
 	}
+
+	$if linux {
+		return new_linux_clipboard()
+	}
 	return new_fallback_clipboard()
 }
 

--- a/src/lib/clipboardv3/clipboard.v
+++ b/src/lib/clipboardv3/clipboard.v
@@ -13,8 +13,8 @@ pub mut:
 }
 
 pub interface Clipboard {
-	get_content() ?ClipboardContent
 mut:
+	get_content() ?ClipboardContent
 	set_content(content ClipboardContent)
 }
 

--- a/src/lib/clipboardv3/clipboard_darwin.c.v
+++ b/src/lib/clipboardv3/clipboard_darwin.c.v
@@ -21,7 +21,7 @@ fn new_darwin_clipboard() Clipboard {
 	return DarwinClipboard{}
 }
 
-fn (c DarwinClipboard) get_content() ?ClipboardContent {
+fn (mut c DarwinClipboard) get_content() ?ClipboardContent {
 	c_content_ptr := C.clipboard_get_content()
 	if c_content_ptr == unsafe { nil } {
 		return none
@@ -48,7 +48,7 @@ fn (c DarwinClipboard) get_content() ?ClipboardContent {
 	return clipboard_content
 }
 
-fn (c DarwinClipboard) set_content(content ClipboardContent) {
+fn (mut c DarwinClipboard) set_content(content ClipboardContent) {
 	C.clipboard_set_content(content.data.str, u8(content.type))
 }
 

--- a/src/lib/clipboardv3/clipboard_fallback.v
+++ b/src/lib/clipboardv3/clipboard_fallback.v
@@ -9,7 +9,7 @@ fn new_fallback_clipboard() Clipboard {
 	return FallbackClipboard{}
 }
 
-fn (clipboard FallbackClipboard) get_content() ?ClipboardContent {
+fn (mut clipboard FallbackClipboard) get_content() ?ClipboardContent {
 	return clipboard.content
 }
 

--- a/src/lib/clipboardv3/clipboard_linux.v
+++ b/src/lib/clipboardv3/clipboard_linux.v
@@ -65,7 +65,6 @@ fn (mut c LinuxClipboard) set_content(content ClipboardContent) {
 			break
 		}
 	}
-	// time.sleep(50 * time.millisecond)
 	c.last_type = content.type
 }
 

--- a/src/lib/clipboardv3/clipboard_linux.v
+++ b/src/lib/clipboardv3/clipboard_linux.v
@@ -1,0 +1,36 @@
+module clipboardv3
+
+import os
+
+struct LinuxClipboard{}
+
+fn new_linux_clipboard() Clipboard {
+	return LinuxClipboard{}
+}
+
+fn (c LinuxClipboard) get_content() ?ClipboardContent {
+	mut cmd := os.new_process("xclip")
+	defer { cmd.close() }
+	cmd.set_args(["-selection", "clipboard", "-out"])
+	cmd.set_redirect_stdio()
+	cmd.run()
+
+	mut data := ""
+	mut read_from_stdout := false
+	if cmd.is_pending(.stdout) {
+		read_from_stdout = true
+		data = cmd.stdout_read()
+	}
+	cmd.wait()
+	if read_from_stdout == false {
+		return none
+	}
+	return ClipboardContent{
+		data: data,
+		type: .block
+	}
+}
+
+fn (c LinuxClipboard) set_content(content ClipboardContent) {
+}
+

--- a/src/lib/clipboardv3/clipboard_linux_test.v
+++ b/src/lib/clipboardv3/clipboard_linux_test.v
@@ -1,0 +1,22 @@
+module clipboardv3
+
+fn test_linux_clipboard_sets_contents() {
+	mut lc := new_linux_clipboard()
+	defer { lc.set_content(ClipboardContent{}) }
+
+	lc.set_content(ClipboardContent{ data: "this is a test line of text" })
+	assert lc.get_content()! == ClipboardContent{
+		data: "this is a test line of text"
+	}
+}
+
+fn test_linux_clipboard_via_interface_sets_contents() {
+	mut c := new()
+	defer { c.set_content(ClipboardContent{}) }
+
+	c.set_content(ClipboardContent{ data: "this is a test line of text via interface wrap" })
+	assert c.get_content()! == ClipboardContent{
+		data: "this is a test line of text via interface wrap"
+	}
+}
+

--- a/src/lib/clipboardv3/clipboard_test.v
+++ b/src/lib/clipboardv3/clipboard_test.v
@@ -16,11 +16,14 @@ fn test_clipboard_native_implementation_sets_type_to_block() ! {
 	} == ClipboardContent{ data: "This is copied text!", type: .block }
 }
 
+@[if darwin ?]
 fn test_clipboard_native_implementation_returns_no_content_type_from_plaintext_data() {
 	$if darwin {
 		C.clipboard_set_plaintext("A plain text sentence with no meta data!".str)
-		clipboard := new()
+		mut clipboard := new()
 		assert clipboard.get_content()! == ClipboardContent{ data: "A plain text sentence with no meta data!", type: .block }
-	} $else { assert true }
+	} $else {
+		assert true == true
+	}
 }
 

--- a/src/lib/clipboardv3/clipboard_test.v
+++ b/src/lib/clipboardv3/clipboard_test.v
@@ -16,10 +16,11 @@ fn test_clipboard_native_implementation_sets_type_to_block() ! {
 	} == ClipboardContent{ data: "This is copied text!", type: .block }
 }
 
-@[if os.darwin ?]
 fn test_clipboard_native_implementation_returns_no_content_type_from_plaintext_data() {
-	C.clipboard_set_plaintext("A plain text sentence with no meta data!".str)
-	clipboard := new()
-	assert clipboard.get_content()! == ClipboardContent{ data: "A plain text sentence with no meta data!", type: .block }
+	$if darwin {
+		C.clipboard_set_plaintext("A plain text sentence with no meta data!".str)
+		clipboard := new()
+		assert clipboard.get_content()! == ClipboardContent{ data: "A plain text sentence with no meta data!", type: .block }
+	} $else { assert true }
 }
 

--- a/src/lib/clipboardv3/x11/clipboard_linux.c.v
+++ b/src/lib/clipboardv3/x11/clipboard_linux.c.v
@@ -1,0 +1,526 @@
+// Currently there is only X11 Selections support and no way to handle Wayland
+// but since Wayland isn't extremely adopted, we are covering almost all Linux distros.
+module x11
+
+import time
+import sync
+
+$if freebsd {
+	#flag -I/usr/local/include
+	#flag -L/usr/local/lib
+} $else $if openbsd {
+	#flag -I/usr/X11R6/include
+	#flag -L/usr/X11R6/lib
+}
+#flag -lX11
+
+#include <X11/Xlib.h> # Please install a package with the X11 development headers, for example: `apt install libx11-dev`
+// X11
+
+@[typedef]
+pub struct C.Display {}
+
+fn (d &C.Display) str() string {
+	return 'C.Display{}'
+}
+
+type Window = u64
+type Atom = u64
+
+fn C.XInitThreads() int
+
+fn C.XCloseDisplay(d &C.Display)
+
+fn C.XFlush(d &C.Display)
+
+fn C.XDestroyWindow(d &C.Display, w Window)
+
+fn C.XNextEvent(d &C.Display, e &C.XEvent)
+
+fn C.XSetSelectionOwner(d &C.Display, a Atom, w Window, time int)
+
+fn C.XGetSelectionOwner(d &C.Display, a Atom) Window
+
+fn C.XChangeProperty(d &C.Display, requestor Window, property Atom, typ Atom, format int, mode int, data voidptr,
+	nelements int) int
+
+fn C.XSendEvent(d &C.Display, requestor Window, propagate int, mask i64, event &C.XEvent)
+
+fn C.XInternAtom(d &C.Display, typ &u8, only_if_exists int) Atom
+
+fn C.XCreateSimpleWindow(d &C.Display, root Window, x int, y int, width u32, height u32, border_width u32,
+	border u64, background u64) Window
+
+fn C.XOpenDisplay(name &u8) &C.Display
+
+fn C.XConvertSelection(d &C.Display, selection Atom, target Atom, property Atom, requestor Window, time int) int
+
+fn C.XSync(d &C.Display, discard int) int
+
+fn C.XGetWindowProperty(d &C.Display, w Window, property Atom, offset i64, length i64, delete int, req_type Atom,
+	actual_type_return &Atom, actual_format_return &int, nitems &u64, bytes_after_return &u64, prop_return &&u8) int
+
+fn C.XDeleteProperty(d &C.Display, w Window, property Atom) int
+
+fn C.DefaultScreen(display &C.Display) int
+
+fn C.RootWindow(display &C.Display, screen_number int) Window
+
+fn C.BlackPixel(display &C.Display, screen_number int) u32
+
+fn C.WhitePixel(display &C.Display, screen_number int) u32
+
+fn C.XFree(data voidptr)
+
+fn todo_del() {}
+
+@[typedef]
+pub struct C.XSelectionRequestEvent {
+mut:
+	display   &C.Display = unsafe { nil } // Display the event was read from
+	owner     Window
+	requestor Window
+	selection Atom
+	target    Atom
+	property  Atom
+	time      int
+}
+
+@[typedef]
+pub struct C.XSelectionEvent {
+mut:
+	type      int
+	display   &C.Display = unsafe { nil } // Display the event was read from
+	requestor Window
+	selection Atom
+	target    Atom
+	property  Atom
+	time      int
+}
+
+@[typedef]
+pub struct C.XSelectionClearEvent {
+mut:
+	window    Window
+	selection Atom
+}
+
+@[typedef]
+pub struct C.XDestroyWindowEvent {
+mut:
+	window Window
+}
+
+@[typedef]
+union C.XEvent {
+mut:
+	type              int
+	xdestroywindow    C.XDestroyWindowEvent
+	xselectionclear   C.XSelectionClearEvent
+	xselectionrequest C.XSelectionRequestEvent
+	xselection        C.XSelectionEvent
+}
+
+const atom_names = ['TARGETS', 'CLIPBOARD', 'CLIPBOARD_MANAGER', 'SAVE_TARGETS', 'PRIMARY', 'SECONDARY', 'TEXT', 'UTF8_STRING',
+	'text/plain', 'text/html']
+
+// UNSUPPORTED TYPES: MULTIPLE, INCR, TIMESTAMP, image/bmp, image/jpeg, image/tiff, image/png
+// all the atom types we need
+// currently we only support text
+// in the future, maybe we can extend this
+// to support other mime types
+enum AtomType {
+	xa_atom           = 0 // value 4
+	xa_string         = 1 // value 31
+	targets           = 2
+	clipboard         = 3
+	clipboard_manager = 4
+	save_targets      = 5
+	primary           = 6
+	secondary         = 7
+	text              = 8
+	utf8_string       = 9
+	text_plain        = 10
+	text_html         = 11
+}
+
+@[heap]
+pub struct Clipboard {
+	display &C.Display = unsafe { nil }
+mut:
+	selection Atom // the selection atom
+	window    Window
+	atoms     []Atom
+	mutex     &sync.Mutex = sync.new_mutex()
+	text      string // text data sent or received
+	got_text  bool   // used to confirm that we have got the text
+	is_owner  bool   // to save selection owner state
+}
+
+struct Property {
+	actual_type   Atom
+	actual_format int
+	nitems        u64
+	data          &u8 = unsafe { nil }
+}
+
+// new_clipboard returns a new `Clipboard` instance allocated on the heap.
+// The `Clipboard` resources can be released with `free()`
+pub fn new_clipboard() &Clipboard {
+	return new_x11_clipboard(.clipboard)
+}
+
+// new_x11_clipboard initializes a new clipboard of the given selection type.
+// Multiple clipboard instance types can be initialized and used separately.
+fn new_x11_clipboard(selection AtomType) &Clipboard {
+	if selection !in [.clipboard, .primary, .secondary] {
+		panic('Wrong AtomType. Must be one of .primary, .secondary or .clipboard.')
+	}
+	// init x11 thread support
+	status := C.XInitThreads()
+	if status == 0 {
+		println('WARN: this system does not support threads; clipboard will cause the program to lock.')
+	}
+
+	display := new_display()
+
+	if display == C.NULL {
+		println('ERROR: No X Server running. Clipboard cannot be used.')
+		return &Clipboard{
+			display: unsafe { nil }
+			mutex:   sync.new_mutex()
+		}
+	}
+
+	mut cb := &Clipboard{
+		display: display
+		window:  create_xwindow(display)
+		mutex:   sync.new_mutex()
+	}
+	cb.intern_atoms()
+	cb.selection = cb.get_atom(selection)
+	// start the listener on another thread or
+	// we will be locked and will have to hard exit
+	spawn cb.start_listener()
+	return cb
+}
+
+// check_availability returns `true` if the clipboard is available for use.
+pub fn (cb &Clipboard) check_availability() bool {
+	return cb.display != C.NULL
+}
+
+// free releases the clipboard resources.
+pub fn (mut cb Clipboard) free() {
+	C.XDestroyWindow(cb.display, cb.window)
+	cb.window = Window(0)
+	// FIXME: program hangs when closing display
+	// XCloseDisplay(cb.display)
+}
+
+// clear clears the clipboard (sets it to an empty string).
+pub fn (mut cb Clipboard) clear() {
+	cb.mutex.lock()
+	C.XSetSelectionOwner(cb.display, cb.selection, Window(0), C.CurrentTime)
+	C.XFlush(cb.display)
+	cb.is_owner = false
+	cb.text = ''
+	cb.mutex.unlock()
+}
+
+// has_ownership returns `true` if the `Clipboard` has the content ownership.
+pub fn (cb &Clipboard) has_ownership() bool {
+	return cb.is_owner
+}
+
+fn (cb &Clipboard) take_ownership() {
+	C.XSetSelectionOwner(cb.display, cb.selection, cb.window, C.CurrentTime)
+	C.XFlush(cb.display)
+}
+
+// set_text stores `text` in the system clipboard.
+pub fn (mut cb Clipboard) set_text(text string) bool {
+	if cb.window == Window(0) {
+		return false
+	}
+	cb.mutex.lock()
+	cb.text = text
+	cb.is_owner = true
+	cb.take_ownership()
+	cb.mutex.unlock()
+	// sleep a little bit
+	time.sleep(1 * time.millisecond)
+	return cb.is_owner
+}
+
+// get_text returns the current entry as a `string` from the clipboard.
+pub fn (mut cb Clipboard) get_text() string {
+	if cb.window == Window(0) {
+		return 'window is 0?'
+	}
+	/*
+	if cb.is_owner {
+		return cb.text
+	}
+	*/
+	cb.got_text = false
+
+	cb.take_ownership()
+	// Request a list of possible conversions, if we're pasting.
+	C.XConvertSelection(cb.display, cb.selection, cb.get_atom(.targets), cb.selection,
+		cb.window, C.CurrentTime)
+
+	// wait for the text to arrive
+	mut retries := 5
+	for {
+		if cb.got_text || retries == 0 {
+			break
+		}
+		time.sleep(50 * time.millisecond)
+		retries--
+	}
+	return cb.text
+}
+
+pub fn (mut cb Clipboard) transfer_to_clipboard_manager() bool {
+    C.XConvertSelection(cb.display, cb.get_atom(.clipboard_manager), cb.get_atom(.save_targets),
+                       C.None, cb.window, C.CurrentTime)
+    // Wait for confirmation...
+    return true
+}
+
+pub fn (mut cb Clipboard) shutdown_with_persistence() {
+    if cb.is_owner && cb.transfer_to_clipboard_manager() {
+    	time.sleep(1 * time.second)
+        // Wait for handoff completion
+    }
+    cb.free()
+}
+
+// transmit_selection is crucial to handling all the different data types.
+// If we ever support other mimetypes they should be handled here.
+fn (mut cb Clipboard) transmit_selection(xse &C.XSelectionEvent) bool {
+	if xse.target == cb.get_atom(.targets) {
+		targets := cb.get_supported_targets()
+		C.XChangeProperty(xse.display, xse.requestor, xse.property, cb.get_atom(.xa_atom),
+			32, C.PropModeReplace, targets.data, targets.len)
+	} else if cb.is_supported_target(xse.target) && cb.is_owner && cb.text != '' {
+		cb.mutex.lock()
+		C.XChangeProperty(xse.display, xse.requestor, xse.property, xse.target, 8, C.PropModeReplace,
+			cb.text.str, cb.text.len)
+		cb.mutex.unlock()
+	} else {
+		return false
+	}
+	return true
+}
+
+fn (mut cb Clipboard) start_listener() {
+	event := C.XEvent{}
+	mut sent_request := false
+	mut to_be_requested := Atom(0)
+	for {
+		time.sleep(1 * time.millisecond)
+		C.XNextEvent(cb.display, &event)
+		if unsafe { event.type == 0 } {
+			println('error')
+			continue
+		}
+		match unsafe { event.type } {
+			C.DestroyNotify {
+				if unsafe { event.xdestroywindow.window == cb.window } {
+					// we are done
+					return
+				}
+			}
+			C.SelectionClear {
+				if unsafe { event.xselectionclear.window == cb.window } && unsafe {
+					event.xselectionclear.selection == cb.selection
+				} {
+					cb.mutex.lock()
+					cb.is_owner = false
+					cb.text = ''
+					cb.mutex.unlock()
+				}
+			}
+			C.SelectionRequest {
+				if unsafe { event.xselectionrequest.selection == cb.selection } {
+					mut xsre := &C.XSelectionRequestEvent{
+						display: 0
+					}
+					xsre = unsafe { &event.xselectionrequest }
+
+					mut xse := C.XSelectionEvent{
+						type:      C.SelectionNotify // 31
+						display:   xsre.display
+						requestor: xsre.requestor
+						selection: xsre.selection
+						time:      xsre.time
+						target:    xsre.target
+						property:  xsre.property
+					}
+					if !cb.transmit_selection(&xse) {
+						xse.property = Atom(0)
+					}
+					C.XSendEvent(cb.display, xse.requestor, 0, C.PropertyChangeMask, voidptr(&xse))
+					C.XFlush(cb.display)
+				}
+			}
+			C.SelectionNotify {
+				if unsafe {
+					event.xselection.selection == cb.selection
+						&& event.xselection.property != Atom(0)
+				} {
+					if unsafe { event.xselection.target == cb.get_atom(.targets) && !sent_request } {
+						sent_request = true
+						prop := read_property(cb.display, cb.window, cb.selection)
+						to_be_requested = cb.pick_target(prop)
+						if to_be_requested != Atom(0) {
+							C.XConvertSelection(cb.display, cb.selection, to_be_requested,
+								cb.selection, cb.window, C.CurrentTime)
+						}
+					} else if unsafe { event.xselection.target == to_be_requested } {
+						sent_request = false
+						to_be_requested = Atom(0)
+						cb.mutex.lock()
+						prop := unsafe {
+							read_property(event.xselection.display, event.xselection.requestor,
+								event.xselection.property)
+						}
+						unsafe {
+							C.XDeleteProperty(event.xselection.display, event.xselection.requestor,
+								event.xselection.property)
+						}
+						if cb.is_supported_target(prop.actual_type) {
+							cb.got_text = true
+							unsafe {
+								cb.text = prop.data.vstring() // TODO: return byteptr to support other mimetypes
+							}
+						}
+						cb.mutex.unlock()
+					}
+				}
+			}
+			C.PropertyNotify {}
+			else {}
+		}
+	}
+}
+
+/*
+* Helpers
+*/
+// intern_atoms initializes all the atoms we need.
+fn (mut cb Clipboard) intern_atoms() {
+	cb.atoms << Atom(4) // XA_ATOM
+	cb.atoms << Atom(31) // XA_STRING
+	for i, name in atom_names {
+		only_if_exists := if i == int(AtomType.utf8_string) { 1 } else { 0 }
+		cb.atoms << C.XInternAtom(cb.display, &char(name.str), only_if_exists)
+		if i == int(AtomType.utf8_string) && cb.atoms[i] == Atom(0) {
+			cb.atoms[i] = cb.get_atom(.xa_string)
+		}
+	}
+}
+
+fn read_property(d &C.Display, w Window, p Atom) Property {
+	actual_type := Atom(0)
+	actual_format := 0
+	nitems := u64(0)
+	bytes_after := u64(0)
+	ret := &u8(unsafe { nil })
+	mut read_bytes := 1024
+	for {
+		if ret != 0 {
+			C.XFree(ret)
+		}
+		C.XGetWindowProperty(d, w, p, 0, read_bytes, 0, 0, &actual_type, &actual_format,
+			&nitems, &bytes_after, &ret)
+		read_bytes *= 2
+		if bytes_after == 0 {
+			break
+		}
+	}
+	return Property{actual_type, actual_format, nitems, ret}
+}
+
+// pick_target finds the best target given a local copy of a property.
+fn (cb &Clipboard) pick_target(prop Property) Atom {
+	// The list of targets is a list of atoms, so it should have type XA_ATOM
+	// but it may have the type TARGETS instead.
+	if (prop.actual_type != cb.get_atom(.xa_atom) && prop.actual_type != cb.get_atom(.targets))
+		|| prop.actual_format != 32 {
+		// This would be really broken. Targets have to be an atom list
+		// and applications should support this. Nevertheless, some
+		// seem broken (MATLAB 7, for instance), so ask for STRING
+		// next instead as the lowest common denominator
+		return cb.get_atom(.xa_string)
+	} else {
+		atom_list := &Atom(voidptr(prop.data))
+
+		mut to_be_requested := Atom(0)
+
+		// This is higher than the maximum priority.
+		mut priority := int(max_i32)
+
+		for i in 0 .. prop.nitems {
+			// See if this data type is allowed and of higher priority (closer to zero)
+			// than the present one.
+
+			target := unsafe { atom_list[i] }
+			if cb.is_supported_target(target) {
+				index := cb.get_target_index(target)
+				if priority > index && index >= 0 {
+					priority = index
+					to_be_requested = target
+				}
+			}
+		}
+		return to_be_requested
+	}
+}
+
+fn (cb &Clipboard) get_atoms(types ...AtomType) []Atom {
+	mut atoms := []Atom{}
+	for typ in types {
+		atoms << cb.atoms[typ]
+	}
+	return atoms
+}
+
+fn (cb &Clipboard) get_atom(typ AtomType) Atom {
+	return cb.atoms[typ]
+}
+
+fn (cb &Clipboard) is_supported_target(target Atom) bool {
+	return cb.get_target_index(target) >= 0
+}
+
+fn (cb &Clipboard) get_target_index(target Atom) int {
+	for i, atom in cb.get_supported_targets() {
+		if atom == target {
+			return i
+		}
+	}
+	return -1
+}
+
+fn (cb &Clipboard) get_supported_targets() []Atom {
+	return cb.get_atoms(AtomType.utf8_string, .xa_string, .text, .text_plain, .text_html)
+}
+
+fn create_xwindow(display &C.Display) Window {
+	n := C.DefaultScreen(display)
+	return C.XCreateSimpleWindow(display, C.RootWindow(display, n), 0, 0, 1, 1, 0, C.BlackPixel(display,
+		n), C.WhitePixel(display, n))
+}
+
+fn new_display() &C.Display {
+	return C.XOpenDisplay(C.NULL)
+}
+
+// new_primary returns a new X11 `PRIMARY` type `Clipboard` instance allocated on the heap.
+// Please note: new_primary only works on X11 based systems.
+pub fn new_primary() &Clipboard {
+	return new_x11_clipboard(.primary)
+}

--- a/src/lilly_test.v
+++ b/src/lilly_test.v
@@ -105,7 +105,9 @@ fn test_lilly_resolve_matches_across_all_open_file_buffers_only_loaded_file_has_
 		] }
 	}
 
+	mut clip := clipboardv3.new()
 	mut lilly := Lilly{
+		clipboard: clip
 		line_reader: mock_fs.read_lines
 		is_binary_file: fn (p string) bool { return false }
 		resolve_workspace_files: fn () []string {
@@ -200,7 +202,10 @@ fn test_lilly_extract_pos_from_path() {
 }
 
 fn test_lilly_resolve_inactive_file_buffer_paths() {
-	mut lilly := Lilly{}
+	mut clip := clipboardv3.new()
+	mut lilly := Lilly{
+		clipboard: clip
+	}
 
 	mut m_line_reader := MockLineReader{
 		line_data: ["This is a fake document that doesn't exist on disk anywhere"]


### PR DESCRIPTION
The ideal solution here is to wrap `xclib.h` from the xclip project and use it much in the same way that xclip itself does. But that was proving tricky, so this will do for now. Should probably add better handling for cases where `xclip` is missing but I want to move on for the time being.