### PR TITLE
wip: set other symbol colour to red to help parser authoring

### DIFF
--- a/src/lib/syntax/syntax.v
+++ b/src/lib/syntax/syntax.v
@@ -27,7 +27,7 @@ pub const colors := {
 	.keyword:             draw.Color{ 255, 95,  175 }
 	.literal:             draw.Color{ 0,  215, 255 }
 	.builtin:             draw.Color{ 130, 144, 250 }
-	.other:               draw.Color{ 200, 200, 235 }
+	.other:               draw.Color{ 255, 0,   0 }
 }
 
 pub struct Syntax {

--- a/src/lib/ui/buffer_view.v
+++ b/src/lib/ui/buffer_view.v
@@ -152,6 +152,7 @@ fn render_token(
 	segment_to_render = utf8.str_clamp_to_visible_length(segment_to_render, max_width - (x_offset - base_x))
 	if segment_to_render.runes().len == 0 { return 0 }
 	// FIX(tauraamui) [27/05/2025]: need to adjust how and when this flag is set
+	// note: I'm now unsure what flag I am on about, likely will remove this note
 	resolved_token_type := match true {
 		token_type        == .comment { token_type }
 		segment_to_render in syntax_def.literals { syntax.TokenType.literal }

--- a/src/view.v
+++ b/src/view.v
@@ -639,8 +639,8 @@ fn (mut view View) draw(mut ctx draw.Contextable) {
 	view.offset_x_and_width_by_len_of_longest_line_number_str(ctx.window_width(), ctx.window_height())
 
 	view.update_to()
-	// view.draw_x(mut ctx)
-	view.draw_document(mut ctx)
+	view.draw_x(mut ctx)
+	// view.draw_document(mut ctx)
 
 	ui.draw_status_line(
 		mut ctx, ui.Status{


### PR DESCRIPTION
By colouring these other symbols as a distinct red this will help adjust the current new parser functionality to improve the new buffer view syntax rendering.

![Screenshot 2025-05-29 at 16 37 16](https://github.com/user-attachments/assets/3d824563-1db4-4cee-8c91-d286e10353df)
