### PR TITLE
Feat/gh 414/render visual selection bg in bufferview

### DIFF
--- a/src/lib/syntax/syntax.v
+++ b/src/lib/syntax/syntax.v
@@ -26,7 +26,9 @@ const builtin_ts_syntax = $embed_file('../../syntax/typescript.syntax').to_strin
 const builtin_python_syntax = $embed_file('../../syntax/python.syntax').to_string()
 const builtin_perl_syntax = $embed_file('../../syntax/perl.syntax').to_string()
 
-pub const colors := {
+pub const colors := $if test { test_colors } $else { non_test_colors }
+
+const non_test_colors := {
 	TokenType.identifier: draw.Color{ 200, 200, 235 }
 	.operator:            draw.Color{ 200, 200, 235 }
 	.string:              draw.Color{ 87,  215, 217 }
@@ -41,6 +43,26 @@ pub const colors := {
 	.literal:             draw.Color{ 0,   215, 255 }
 	.builtin:             draw.Color{ 130, 144, 250 }
 	.other:               draw.Color{ 200, 200, 235 }
+}
+
+// NOTE(tauraamui) [10/06/2025]: these colors don't need to be valid at all they're only
+//                               here to ensure that colour lookups in tests provide
+//                               unique results
+const test_colors := {
+	TokenType.identifier: draw.Color{ 999, 999, 999 }
+	.operator:            draw.Color{ 987, 987, 987 }
+	.string:              draw.Color{ 950, 950, 950 }
+	.comment:             draw.Color{ 943, 943, 943 }
+	.comment_start:       draw.Color{ 932, 932, 932 }
+	.comment_end:         draw.Color{ 920, 920, 920 }
+	.block_start:         draw.Color{ 919, 919, 919 }
+	.block_end:           draw.Color{ 915, 915, 915 }
+	.number:              draw.Color{ 909, 909, 909 }
+	.whitespace:          draw.Color{ 875, 445, 789 }
+	.keyword:             draw.Color{ 585, 321, 555 }
+	.literal:             draw.Color{ 289, 287, 285 }
+	.builtin:             draw.Color{ 543, 598, 555 }
+	.other:               draw.Color{ 874, 333, 401 }
 }
 
 pub fn color_to_type(color draw.Color) ?TokenType {

--- a/src/lib/syntax/syntax.v
+++ b/src/lib/syntax/syntax.v
@@ -38,9 +38,15 @@ pub const colors := {
 	.number:              draw.Color{ 215, 135, 215 }
 	.whitespace:          draw.Color{ 200, 200, 235 }
 	.keyword:             draw.Color{ 255, 95,  175 }
-	.literal:             draw.Color{ 0,  215, 255 }
+	.literal:             draw.Color{ 0,   215, 255 }
 	.builtin:             draw.Color{ 130, 144, 250 }
 	.other:               draw.Color{ 200, 200, 235 }
+}
+
+pub fn color_to_type(color draw.Color) ?TokenType {
+	index := colors.values().index(color)
+	if index < 0 { return none }
+	return colors.keys()[index]
 }
 
 pub struct Syntax {

--- a/src/lib/ui/buffer_cursor.v
+++ b/src/lib/ui/buffer_cursor.v
@@ -1,9 +1,18 @@
 module ui
 
+import lib.core
+
 pub struct CursorPos {
 pub mut:
 	x int
 	y int
+}
+
+pub struct SelectionSpan {
+pub:
+	min_x int
+	max_x int
+	full bool
 }
 
 pub struct BufferCursor {
@@ -13,6 +22,7 @@ pub mut:
 	pos                 CursorPos
 }
 
+// TODO(tauraamui) [11/06/2025]: make this private
 pub fn (cursor BufferCursor) y_within_selection(line_y int) bool {
 	if sel_pos := cursor.sel_start_pos {
 		// NOTE(tauraamui) [06/06/2025]: need to write a style guide for this project one day
@@ -26,6 +36,10 @@ pub fn (cursor BufferCursor) y_within_selection(line_y int) bool {
 		return line_y >= start && line_y <= end
 	}
 	return false
+}
+
+pub fn (cursor BufferCursor) resolve_line_selection_span(mode core.Mode, line_y int) SelectionSpan {
+	return SelectionSpan{ full: mode == .visual_line && cursor.y_within_selection(line_y) }
 }
 
 pub fn (cursor BufferCursor) sel_start() ?CursorPos {

--- a/src/lib/ui/buffer_cursor_test.v
+++ b/src/lib/ui/buffer_cursor_test.v
@@ -36,6 +36,9 @@ fn test_cursor_resolve_line_selection_span_if_visual_and_y_in_selection_start_x_
 fn test_cursor_resolve_line_selection_span_if_visual_and_y_in_selection_starts_ends_on_same_line() {
 	mut cursor := BufferCursor{ pos: CursorPos{ x: 20, y: 3 }, sel_start_pos: CursorPos{ 10, 3 } }
 	assert cursor.resolve_line_selection_span(.visual, 30, 3) == SelectionSpan{ min_x: 10, max_x: 20, full: false }
+
+	cursor = BufferCursor{ pos: CursorPos{ x: 15, y: 3 }, sel_start_pos: CursorPos{ 0, 3 } }
+	assert cursor.resolve_line_selection_span(.visual, 30, 3) == SelectionSpan{ min_x: 0, max_x: 15, full: false }
 }
 
 fn test_cursor_check_if_line_within_selection_in_order() {

--- a/src/lib/ui/buffer_cursor_test.v
+++ b/src/lib/ui/buffer_cursor_test.v
@@ -33,6 +33,11 @@ fn test_cursor_resolve_line_selection_span_if_visual_and_y_in_selection_start_x_
 	assert cursor.resolve_line_selection_span(.visual, 30, 10) == SelectionSpan{ min_x: 0, max_x: 25, full: false }
 }
 
+fn test_cursor_resolve_line_selection_span_if_visual_and_y_in_selection_starts_ends_on_same_line() {
+	mut cursor := BufferCursor{ pos: CursorPos{ x: 20, y: 3 }, sel_start_pos: CursorPos{ 10, 3 } }
+	assert cursor.resolve_line_selection_span(.visual, 30, 3) == SelectionSpan{ min_x: 10, max_x: 20, full: false }
+}
+
 fn test_cursor_check_if_line_within_selection_in_order() {
 	cursor := BufferCursor{ pos: CursorPos{ x: 0, y: 3 }, sel_start_pos: CursorPos{ 0, 10 } }
 	assert cursor.y_within_selection(8)

--- a/src/lib/ui/buffer_cursor_test.v
+++ b/src/lib/ui/buffer_cursor_test.v
@@ -1,5 +1,30 @@
 module ui
 
+fn test_cursor_resolve_line_selection_span_if_visual_line_and_y_in_selection_x_zeroed_out() {
+	cursor := BufferCursor{ pos: CursorPos{ x: 0, y: 3 }, sel_start_pos: CursorPos{ 0, 10 } }
+	assert cursor.resolve_line_selection_span(.visual_line, 30, 5) == SelectionSpan{ full: true }
+}
+
+fn test_cursor_resolve_line_selection_span_if_visual_line_and_y_not_in_selection_x_zeroed_out() {
+	cursor := BufferCursor{ pos: CursorPos{ x: 0, y: 3 }, sel_start_pos: CursorPos{ 0, 10 } }
+	assert cursor.resolve_line_selection_span(.visual_line, 30, 25) == SelectionSpan{ full: false }
+}
+
+fn test_cursor_resolve_line_selection_span_if_visual_line_and_y_in_selection_start_x_end_x_not_floored() {
+	cursor := BufferCursor{ pos: CursorPos{ x: 10, y: 3 }, sel_start_pos: CursorPos{ 25, 10 } }
+	assert cursor.resolve_line_selection_span(.visual_line, 30, 4) == SelectionSpan{ full: true }
+}
+
+fn test_cursor_resolve_line_selection_span_if_visual_line_and_y_not_in_selection_start_x_end_x_not_floored() {
+	cursor := BufferCursor{ pos: CursorPos{ x: 10, y: 3 }, sel_start_pos: CursorPos{ 25, 10 } }
+	assert cursor.resolve_line_selection_span(.visual_line, 30, 2) == SelectionSpan{ full: false }
+}
+
+fn test_cursor_resolve_line_selection_span_if_visual_and_y_in_selection_start_x_end_x_not_floored() {
+	cursor := BufferCursor{ pos: CursorPos{ x: 10, y: 3 }, sel_start_pos: CursorPos{ 25, 10 } }
+	assert cursor.resolve_line_selection_span(.visual, 30, 3) == SelectionSpan{ min_x: 10, max_x: 30, full: false }
+}
+
 fn test_cursor_check_if_line_within_selection_in_order() {
 	cursor := BufferCursor{ pos: CursorPos{ x: 0, y: 3 }, sel_start_pos: CursorPos{ 0, 10 } }
 	assert cursor.y_within_selection(8)

--- a/src/lib/ui/buffer_cursor_test.v
+++ b/src/lib/ui/buffer_cursor_test.v
@@ -21,8 +21,16 @@ fn test_cursor_resolve_line_selection_span_if_visual_line_and_y_not_in_selection
 }
 
 fn test_cursor_resolve_line_selection_span_if_visual_and_y_in_selection_start_x_end_x_not_floored() {
-	cursor := BufferCursor{ pos: CursorPos{ x: 10, y: 3 }, sel_start_pos: CursorPos{ 25, 10 } }
+	mut cursor := BufferCursor{ pos: CursorPos{ x: 10, y: 3 }, sel_start_pos: CursorPos{ 25, 10 } }
 	assert cursor.resolve_line_selection_span(.visual, 30, 3) == SelectionSpan{ min_x: 10, max_x: 30, full: false }
+
+	// this selection span is for the full line as the requested y is neither the first or last lines
+	cursor = BufferCursor{ pos: CursorPos{ x: 10, y: 3 }, sel_start_pos: CursorPos{ x: 25, y: 10 } }
+	assert cursor.resolve_line_selection_span(.visual, 30, 8) == SelectionSpan{ min_x: 0, max_x: 30, full: true }
+
+	// the selection span has a clamped max as the line y is the last line of the selection
+	cursor = BufferCursor{ pos: CursorPos{ x: 10, y: 3 }, sel_start_pos: CursorPos{ x: 25, y: 10 } }
+	assert cursor.resolve_line_selection_span(.visual, 30, 10) == SelectionSpan{ min_x: 0, max_x: 25, full: false }
 }
 
 fn test_cursor_check_if_line_within_selection_in_order() {

--- a/src/lib/ui/buffer_view.v
+++ b/src/lib/ui/buffer_view.v
@@ -165,7 +165,7 @@ fn draw_text_line(
 			current_token, next_token, syntax_def,
 			x, max_width,
 			visual_x_offset, y,
-			cursor.resolve_line_selection_span(current_mode, document_line_num),
+			cursor.resolve_line_selection_span(current_mode, line.runes().len, document_line_num),
 			selection_highlight_color
 		)
 		previous_token = current_token

--- a/src/lib/ui/buffer_view.v
+++ b/src/lib/ui/buffer_view.v
@@ -45,7 +45,8 @@ pub fn (mut buf_view BufferView) draw(
 	min_x int,
 	relative_line_nums bool,
 	current_mode core.Mode,
-	cursor BufferCursor
+	cursor BufferCursor,
+	selection_highlight_color draw.Color
 ) {
 	cursor_y_pos := cursor.pos.y
 	if buf_view.buf == unsafe { nil } { return }
@@ -80,13 +81,15 @@ pub fn (mut buf_view BufferView) draw(
 			current_mode,
 			x + screenspace_x_offset + 1,
 			y + screenspace_y_offset,
+			document_line_num,
 			line,
 			syntax_parser.get_line_tokens(document_line_num),
 			syntax_def,
 			min_x,
 			width,
 			is_cursor_line,
-			cursor
+			cursor,
+			selection_highlight_color
 		)
 
 		screenspace_y_offset += 1
@@ -133,12 +136,14 @@ fn draw_text_line(
 	mut ctx draw.Contextable,
 	current_mode core.Mode,
 	x int, y int,
+	document_line_num int,
 	line string,
 	line_tokens []syntax.Token,
 	syntax_def syntax.Syntax,
 	min_x int, width int,
 	is_cursor_line bool,
-	cursor BufferCursor
+	cursor BufferCursor,
+	selection_highlight_color draw.Color
 ) {
 	max_width := width - x
 	if current_mode != .visual_line && is_cursor_line { // no point in setting the bg in this case
@@ -158,8 +163,10 @@ fn draw_text_line(
 			mut ctx, line,
 			cur_token_bounds, previous_token,
 			current_token, next_token, syntax_def,
-			min_x, x, max_width,
-			visual_x_offset, y
+			x, max_width,
+			visual_x_offset, y,
+			cursor.resolve_line_selection_span(current_mode, document_line_num),
+			selection_highlight_color
 		)
 		previous_token = current_token
 	}
@@ -186,8 +193,10 @@ fn render_token(
 	current_token syntax.Token,
 	next_token ?syntax.Token,
 	syntax_def syntax.Syntax,
-	min_x int, base_x int,
-	max_width int, x_offset int, y int
+	base_x int, max_width int,
+	x_offset int, y int,
+	selected_span SelectionSpan,
+	selection_highlight_color draw.Color
 ) int {
 	mut segment_to_render := line.runes()[cur_token_bounds.start..cur_token_bounds.end].string().replace("\t", " ".repeat(4))
 	segment_to_render = utf8.str_clamp_to_visible_length(segment_to_render, max_width - (x_offset - base_x))
@@ -208,6 +217,11 @@ fn render_token(
 	}
 
 	ctx.set_color(syntax.colors[resolved_token_type])
+	if selected_span.full {
+		ctx.set_bg_color(selection_highlight_color)
+		defer { ctx.reset_bg_color() }
+		ctx.reset_color()
+	}
 	ctx.draw_text(x_offset, y, segment_to_render)
 	return utf8_str_visible_length(segment_to_render)
 }

--- a/src/lib/ui/buffer_view_test.v
+++ b/src/lib/ui/buffer_view_test.v
@@ -1081,6 +1081,141 @@ fn test_buffer_view_draws_lines_10_to_max_height_relative_line_numbers_enabled_c
 	assert syntax.color_to_type(set_fg_color[12])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[13])? == .identifier
 
+	assert set_fg_color[14] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[15])? == .identifier
+	assert syntax.color_to_type(set_fg_color[16])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[17])? == .identifier
+	assert syntax.color_to_type(set_fg_color[18])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[19])? == .identifier
+	assert syntax.color_to_type(set_fg_color[20])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[21])? == .number
+	assert syntax.color_to_type(set_fg_color[22])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[23])? == .identifier
+	assert syntax.color_to_type(set_fg_color[24])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[25])? == .identifier
+	assert syntax.color_to_type(set_fg_color[26])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[27])? == .identifier
+
+	assert set_fg_color[28] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[29])? == .identifier
+	assert syntax.color_to_type(set_fg_color[30])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[31])? == .identifier
+	assert syntax.color_to_type(set_fg_color[33])? == .identifier
+	assert syntax.color_to_type(set_fg_color[34])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[35])? == .number
+	assert syntax.color_to_type(set_fg_color[36])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[37])? == .identifier
+	assert syntax.color_to_type(set_fg_color[38])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[39])? == .identifier
+	assert syntax.color_to_type(set_fg_color[40])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[41])? == .identifier
+
+	assert set_fg_color[42] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[43])? == .identifier
+	assert syntax.color_to_type(set_fg_color[44])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[45])? == .identifier
+	assert syntax.color_to_type(set_fg_color[46])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[47])? == .identifier
+	assert syntax.color_to_type(set_fg_color[48])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[49])? == .number
+	assert syntax.color_to_type(set_fg_color[50])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[51])? == .identifier
+	assert syntax.color_to_type(set_fg_color[52])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[53])? == .identifier
+	assert syntax.color_to_type(set_fg_color[54])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[55])? == .identifier
+
+	assert set_fg_color[56] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[57])? == .identifier
+	assert syntax.color_to_type(set_fg_color[58])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[59])? == .identifier
+	assert syntax.color_to_type(set_fg_color[60])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[61])? == .identifier
+	assert syntax.color_to_type(set_fg_color[62])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[63])? == .number
+	assert syntax.color_to_type(set_fg_color[64])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[65])? == .identifier
+	assert syntax.color_to_type(set_fg_color[66])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[67])? == .identifier
+	assert syntax.color_to_type(set_fg_color[68])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[69])? == .identifier
+
+	assert set_fg_color[70] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[71])? == .identifier
+	assert syntax.color_to_type(set_fg_color[72])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[73])? == .identifier
+	assert syntax.color_to_type(set_fg_color[74])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[75])? == .identifier
+	assert syntax.color_to_type(set_fg_color[76])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[77])? == .number
+	assert syntax.color_to_type(set_fg_color[78])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[79])? == .identifier
+	assert syntax.color_to_type(set_fg_color[80])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[81])? == .identifier
+	assert syntax.color_to_type(set_fg_color[82])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[83])? == .identifier
+
+	assert set_fg_color[84] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[85])? == .identifier
+	assert syntax.color_to_type(set_fg_color[86])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[87])? == .identifier
+	assert syntax.color_to_type(set_fg_color[88])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[89])? == .identifier
+	assert syntax.color_to_type(set_fg_color[90])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[91])? == .number
+	assert syntax.color_to_type(set_fg_color[92])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[93])? == .identifier
+	assert syntax.color_to_type(set_fg_color[94])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[95])? == .identifier
+	assert syntax.color_to_type(set_fg_color[96])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[97])? == .identifier
+
+	assert set_fg_color[98] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[99])? == .identifier
+	assert syntax.color_to_type(set_fg_color[100])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[101])? == .identifier
+	assert syntax.color_to_type(set_fg_color[102])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[103])? == .identifier
+	assert syntax.color_to_type(set_fg_color[104])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[105])? == .number
+	assert syntax.color_to_type(set_fg_color[106])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[107])? == .identifier
+	assert syntax.color_to_type(set_fg_color[108])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[109])? == .identifier
+	assert syntax.color_to_type(set_fg_color[110])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[111])? == .identifier
+
+	assert set_fg_color[112] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[113])? == .identifier
+	assert syntax.color_to_type(set_fg_color[114])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[115])? == .identifier
+	assert syntax.color_to_type(set_fg_color[116])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[117])? == .identifier
+	assert syntax.color_to_type(set_fg_color[118])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[119])? == .number
+	assert syntax.color_to_type(set_fg_color[120])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[121])? == .identifier
+	assert syntax.color_to_type(set_fg_color[122])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[123])? == .identifier
+	assert syntax.color_to_type(set_fg_color[124])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[125])? == .identifier
+
+	assert set_fg_color[126] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[127])? == .identifier
+	assert syntax.color_to_type(set_fg_color[127])? == .identifier
+	assert syntax.color_to_type(set_fg_color[128])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[129])? == .identifier
+	assert syntax.color_to_type(set_fg_color[130])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[131])? == .identifier
+	assert syntax.color_to_type(set_fg_color[132])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[133])? == .number
+	assert syntax.color_to_type(set_fg_color[134])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[135])? == .identifier
+	assert syntax.color_to_type(set_fg_color[136])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[137])? == .identifier
+	assert syntax.color_to_type(set_fg_color[138])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[139])? == .identifier
+
 	assert drawn_text[0] == DrawnText{ x: 1, y: 0, data: "5" }
 	assert drawn_text[14] == DrawnText{ x: 1, y: 1, data: "4" }
 	assert drawn_text[28] == DrawnText{ x: 1, y: 2, data: "3" }

--- a/src/lib/ui/buffer_view_test.v
+++ b/src/lib/ui/buffer_view_test.v
@@ -521,6 +521,19 @@ fn test_buffer_view_draws_lines_10_to_max_height() {
 	assert syntax.color_to_type(set_fg_color[78])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[79])? == .identifier
 
+	assert set_fg_color[80] == draw.Color{ 107, 189, 21 } // TODO(tauraamui) [10/06/2025]: figure out where this specific colour is coming from
+	assert syntax.color_to_type(set_fg_color[81])? == .identifier
+	assert syntax.color_to_type(set_fg_color[82])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[83])? == .identifier
+	assert set_fg_color[84] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[85])? == .identifier
+	assert syntax.color_to_type(set_fg_color[86])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[87])? == .identifier
+	assert syntax.color_to_type(set_fg_color[88])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[89])? == .identifier
+	assert syntax.color_to_type(set_fg_color[90])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[91])? == .number
+
 	line_one_expected_drawn_data := [
 		DrawnText{ x: 0, y: 0, data: "11" }, DrawnText{ x: 3, y: 0, data: "This" },
 		DrawnText{ x: 7, y: 0, data: " " }, DrawnText{ x: 8, y: 0, data: "is" },

--- a/src/lib/ui/buffer_view_test.v
+++ b/src/lib/ui/buffer_view_test.v
@@ -17,6 +17,7 @@ module ui
 import lib.buffer
 import lib.draw
 import lib.utf8
+import lib.syntax
 
 struct DrawnText {
 	x int
@@ -38,6 +39,9 @@ fn test_buffer_view_draws_lines_0_to_max_height() {
 	mut set_fg_color := []draw.Color{}
 	mut set_fg_color_ref := &set_fg_color
 
+	mut set_bg_color := []draw.Color{}
+	mut set_bg_color_ref := &set_bg_color
+
 	mut drawn_rect := []DrawnRect{}
 	mut drawn_rect_ref := &drawn_rect
 
@@ -50,6 +54,9 @@ fn test_buffer_view_draws_lines_0_to_max_height() {
 		}
 		on_set_fg_color_cb: fn [mut set_fg_color_ref] (c draw.Color) {
 			set_fg_color_ref << c
+		}
+		on_set_bg_color_cb: fn [mut set_bg_color_ref] (c draw.Color) {
+			set_bg_color_ref << c
 		}
 	}
 
@@ -70,12 +77,74 @@ fn test_buffer_view_draws_lines_0_to_max_height() {
 		min_x, false, .normal, BufferCursor{}
 	)
 
+	assert set_bg_color == [draw.Color{ 53, 53, 53 }, draw.Color{ 53, 53, 53 }]
 	assert drawn_rect == [
 		DrawnRect{ x: 2, y: 0, width: 99, height: 1 }
 	]
 
 	assert drawn_text.len == 56
 	assert set_fg_color.len == 56
+
+	// this is the line at the side being rendered
+	assert set_fg_color[0] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[1])? == .identifier
+	assert syntax.color_to_type(set_fg_color[2])? == .identifier
+	assert syntax.color_to_type(set_fg_color[3])? == .identifier
+	assert syntax.color_to_type(set_fg_color[4])? == .identifier
+	assert syntax.color_to_type(set_fg_color[5])? == .identifier
+	assert syntax.color_to_type(set_fg_color[6])? == .identifier
+	assert syntax.color_to_type(set_fg_color[7])? == .number
+	assert syntax.color_to_type(set_fg_color[8])? == .identifier
+	assert syntax.color_to_type(set_fg_color[9])? == .identifier
+	assert syntax.color_to_type(set_fg_color[10])? == .identifier
+	assert syntax.color_to_type(set_fg_color[11])? == .identifier
+	assert syntax.color_to_type(set_fg_color[12])? == .identifier
+	assert syntax.color_to_type(set_fg_color[13])? == .identifier
+
+	assert set_fg_color[14] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[15])? == .identifier
+	assert syntax.color_to_type(set_fg_color[16])? == .identifier
+	assert syntax.color_to_type(set_fg_color[17])? == .identifier
+	assert syntax.color_to_type(set_fg_color[18])? == .identifier
+	assert syntax.color_to_type(set_fg_color[19])? == .identifier
+	assert syntax.color_to_type(set_fg_color[20])? == .identifier
+	assert syntax.color_to_type(set_fg_color[21])? == .number
+	assert syntax.color_to_type(set_fg_color[22])? == .identifier
+	assert syntax.color_to_type(set_fg_color[23])? == .identifier
+	assert syntax.color_to_type(set_fg_color[24])? == .identifier
+	assert syntax.color_to_type(set_fg_color[25])? == .identifier
+	assert syntax.color_to_type(set_fg_color[26])? == .identifier
+	assert syntax.color_to_type(set_fg_color[27])? == .identifier
+
+	assert set_fg_color[28] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[29])? == .identifier
+	assert syntax.color_to_type(set_fg_color[30])? == .identifier
+	assert syntax.color_to_type(set_fg_color[31])? == .identifier
+	assert syntax.color_to_type(set_fg_color[32])? == .identifier
+	assert syntax.color_to_type(set_fg_color[33])? == .identifier
+	assert syntax.color_to_type(set_fg_color[34])? == .identifier
+	assert syntax.color_to_type(set_fg_color[35])? == .number
+	assert syntax.color_to_type(set_fg_color[36])? == .identifier
+	assert syntax.color_to_type(set_fg_color[37])? == .identifier
+	assert syntax.color_to_type(set_fg_color[38])? == .identifier
+	assert syntax.color_to_type(set_fg_color[39])? == .identifier
+	assert syntax.color_to_type(set_fg_color[40])? == .identifier
+	assert syntax.color_to_type(set_fg_color[41])? == .identifier
+
+	assert set_fg_color[42] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[43])? == .identifier
+	assert syntax.color_to_type(set_fg_color[44])? == .identifier
+	assert syntax.color_to_type(set_fg_color[45])? == .identifier
+	assert syntax.color_to_type(set_fg_color[46])? == .identifier
+	assert syntax.color_to_type(set_fg_color[47])? == .identifier
+	assert syntax.color_to_type(set_fg_color[48])? == .identifier
+	assert syntax.color_to_type(set_fg_color[49])? == .number
+	assert syntax.color_to_type(set_fg_color[50])? == .identifier
+	assert syntax.color_to_type(set_fg_color[51])? == .identifier
+	assert syntax.color_to_type(set_fg_color[52])? == .identifier
+	assert syntax.color_to_type(set_fg_color[53])? == .identifier
+	assert syntax.color_to_type(set_fg_color[54])? == .identifier
+	assert syntax.color_to_type(set_fg_color[55])? == .identifier
 
 	// TODO(tauraamui) [14/04/2025]: need to assert against style draws as well
 	line_one_expected_drawn_data := [
@@ -119,6 +188,9 @@ fn test_buffer_view_draws_1_line_as_single_segment_that_that_elapses_max_width()
 	mut set_fg_color := []draw.Color{}
 	mut set_fg_color_ref := &set_fg_color
 
+	mut set_bg_color := []draw.Color{}
+	mut set_bg_color_ref := &set_bg_color
+
 	mut drawn_rect := []DrawnRect{}
 	mut drawn_rect_ref := &drawn_rect
 
@@ -131,6 +203,9 @@ fn test_buffer_view_draws_1_line_as_single_segment_that_that_elapses_max_width()
 		}
 		on_set_fg_color_cb: fn [mut set_fg_color_ref] (c draw.Color) {
 			set_fg_color_ref << c
+		}
+		on_set_bg_color_cb: fn [mut set_bg_color_ref] (c draw.Color) {
+			set_bg_color_ref << c
 		}
 	}
 
@@ -152,12 +227,16 @@ fn test_buffer_view_draws_1_line_as_single_segment_that_that_elapses_max_width()
 	)
 
 	// TODO(tauraamui) [14/04/2025]: need to assert against style draws as well
+	assert set_bg_color == [draw.Color{ 53, 53, 53 }, draw.Color{ 53, 53, 53 }]
 	assert drawn_rect == [
 		DrawnRect{ x: 2, y: 0, width: 19, height: 1 }
 	]
 
 	assert drawn_text.len == 2
 	assert set_fg_color.len == 2
+
+	assert set_fg_color[0] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[1])? == .identifier
 
 	line_one_expected_drawn_data := [
 		DrawnText{ x: 0, y: 0, data: "1" }, DrawnText{ x: 2, y: 0, data: "Thisisthelineinthe" },
@@ -172,6 +251,9 @@ fn test_buffer_view_draws_1_line_as_multiple_segments_highlighted_as_expected() 
 	mut set_fg_color := []draw.Color{}
 	mut set_fg_color_ref := &set_fg_color
 
+	mut set_bg_color := []draw.Color{}
+	mut set_bg_color_ref := &set_bg_color
+
 	mut drawn_rect := []DrawnRect{}
 	mut drawn_rect_ref := &drawn_rect
 
@@ -184,6 +266,9 @@ fn test_buffer_view_draws_1_line_as_multiple_segments_highlighted_as_expected() 
 		}
 		on_set_fg_color_cb: fn [mut set_fg_color_ref] (c draw.Color) {
 			set_fg_color_ref << c
+		}
+		on_set_bg_color_cb: fn [mut set_bg_color_ref] (c draw.Color) {
+			set_bg_color_ref << c
 		}
 	}
 
@@ -205,12 +290,23 @@ fn test_buffer_view_draws_1_line_as_multiple_segments_highlighted_as_expected() 
 	)
 
 	// TODO(tauraamui) [14/04/2025]: need to assert against style draws as well
+	assert set_bg_color == [draw.Color{ 53, 53, 53 }, draw.Color{ 53, 53, 53 }]
 	assert drawn_rect == [
 		DrawnRect{ x: 2, y: 0, width: 39, height: 1 }
 	]
 
 	assert drawn_text.len == 9
 	assert set_fg_color.len == 9
+
+	assert set_fg_color[0] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[1])? == .identifier
+	assert syntax.color_to_type(set_fg_color[2])? == .identifier
+	assert syntax.color_to_type(set_fg_color[3])? == .identifier
+	assert syntax.color_to_type(set_fg_color[4])? == .identifier
+	assert syntax.color_to_type(set_fg_color[5])? == .identifier
+	assert syntax.color_to_type(set_fg_color[6])? == .identifier
+	assert syntax.color_to_type(set_fg_color[7])? == .identifier
+	assert syntax.color_to_type(set_fg_color[8])? == .identifier
 
 	line_one_expected_drawn_data := [
 		DrawnText{ x: 0, y: 0, data: "1" }, DrawnText{ x: 2, y: 0, data: "fn" },
@@ -229,6 +325,9 @@ fn test_buffer_view_draws_1_line_as_single_segment_single_emoji() {
 	mut set_fg_color := []draw.Color{}
 	mut set_fg_color_ref := &set_fg_color
 
+	mut set_bg_color := []draw.Color{}
+	mut set_bg_color_ref := &set_bg_color
+
 	mut drawn_rect := []DrawnRect{}
 	mut drawn_rect_ref := &drawn_rect
 
@@ -241,6 +340,9 @@ fn test_buffer_view_draws_1_line_as_single_segment_single_emoji() {
 		}
 		on_set_fg_color_cb: fn [mut set_fg_color_ref] (c draw.Color) {
 			set_fg_color_ref << c
+		}
+		on_set_bg_color_cb: fn [mut set_bg_color_ref] (c draw.Color) {
+			set_bg_color_ref << c
 		}
 	}
 
@@ -262,12 +364,16 @@ fn test_buffer_view_draws_1_line_as_single_segment_single_emoji() {
 	)
 
 	// TODO(tauraamui) [14/04/2025]: need to assert against style draws as well
+	assert set_bg_color == [draw.Color{ 53, 53, 53 }, draw.Color{ 53, 53, 53 }]
 	assert drawn_rect == [
 		DrawnRect{ x: 2, y: 0, width: 19, height: 1 }
 	]
 
 	assert drawn_text.len == 2
 	assert set_fg_color.len == 2
+
+	assert set_fg_color[0] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[1])? == .identifier
 
 	line_one_expected_drawn_data := [
 		DrawnText{ x: 0, y: 0, data: "1" }, DrawnText{ x: 2, y: 0, data: "${utf8.emoji_shark_char}" },
@@ -283,6 +389,9 @@ fn test_buffer_view_draws_lines_10_to_max_height() {
 	mut set_fg_color := []draw.Color{}
 	mut set_fg_color_ref := &set_fg_color
 
+	mut set_bg_color := []draw.Color{}
+	mut set_bg_color_ref := &set_bg_color
+
 	mut drawn_rect := []DrawnRect{}
 	mut drawn_rect_ref := &drawn_rect
 
@@ -295,6 +404,9 @@ fn test_buffer_view_draws_lines_10_to_max_height() {
 		}
 		on_set_fg_color_cb: fn [mut set_fg_color_ref] (c draw.Color) {
 			set_fg_color_ref << c
+		}
+		on_set_bg_color_cb: fn [mut set_bg_color_ref] (c draw.Color) {
+			set_bg_color_ref << c
 		}
 	}
 
@@ -316,12 +428,43 @@ fn test_buffer_view_draws_lines_10_to_max_height() {
 	)
 
 	// TODO(tauraamui) [14/04/2025]: need to assert against style draws as well
+	assert set_bg_color == [draw.Color{ 53, 53, 53 }, draw.Color{ 53, 53, 53 }]
 	assert drawn_rect == [
 		DrawnRect{ x: 3, y: 2, width: 98, height: 1 }
 	]
 
 	assert drawn_text.len == 140
 	assert set_fg_color.len == 140
+
+	assert set_fg_color[0] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[1])? == .identifier
+	assert syntax.color_to_type(set_fg_color[2])? == .identifier
+	assert syntax.color_to_type(set_fg_color[3])? == .identifier
+	assert syntax.color_to_type(set_fg_color[4])? == .identifier
+	assert syntax.color_to_type(set_fg_color[5])? == .identifier
+	assert syntax.color_to_type(set_fg_color[6])? == .identifier
+	assert syntax.color_to_type(set_fg_color[7])? == .number
+	assert syntax.color_to_type(set_fg_color[8])? == .identifier
+	assert syntax.color_to_type(set_fg_color[9])? == .identifier
+	assert syntax.color_to_type(set_fg_color[10])? == .identifier
+	assert syntax.color_to_type(set_fg_color[11])? == .identifier
+	assert syntax.color_to_type(set_fg_color[12])? == .identifier
+	assert syntax.color_to_type(set_fg_color[13])? == .identifier
+
+	assert set_fg_color[14] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[15])? == .identifier
+	assert syntax.color_to_type(set_fg_color[16])? == .identifier
+	assert syntax.color_to_type(set_fg_color[17])? == .identifier
+	assert syntax.color_to_type(set_fg_color[18])? == .identifier
+	assert syntax.color_to_type(set_fg_color[19])? == .identifier
+	assert syntax.color_to_type(set_fg_color[20])? == .identifier
+	assert syntax.color_to_type(set_fg_color[21])? == .number
+	assert syntax.color_to_type(set_fg_color[22])? == .identifier
+	assert syntax.color_to_type(set_fg_color[23])? == .identifier
+	assert syntax.color_to_type(set_fg_color[24])? == .identifier
+	assert syntax.color_to_type(set_fg_color[25])? == .identifier
+	assert syntax.color_to_type(set_fg_color[26])? == .identifier
+	assert syntax.color_to_type(set_fg_color[27])? == .identifier
 
 	line_one_expected_drawn_data := [
 		DrawnText{ x: 0, y: 0, data: "11" }, DrawnText{ x: 3, y: 0, data: "This" },
@@ -697,6 +840,9 @@ fn test_buffer_view_draws_lines_0_to_max_height_min_x_0_max_width_14() {
 	mut set_fg_color := []draw.Color{}
 	mut set_fg_color_ref := &set_fg_color
 
+	mut set_bg_color := []draw.Color{}
+	mut set_bg_color_ref := &set_bg_color
+
 	mut drawn_rect := []DrawnRect{}
 	mut drawn_rect_ref := &drawn_rect
 
@@ -709,6 +855,9 @@ fn test_buffer_view_draws_lines_0_to_max_height_min_x_0_max_width_14() {
 		}
 		on_set_fg_color_cb: fn [mut set_fg_color_ref] (c draw.Color) {
 			set_fg_color_ref << c
+		}
+		on_set_bg_color_cb: fn [mut set_bg_color_ref] (c draw.Color) {
+			set_bg_color_ref << c
 		}
 	}
 
@@ -726,12 +875,43 @@ fn test_buffer_view_draws_lines_0_to_max_height_min_x_0_max_width_14() {
 	buf_view.draw(mut mock_ctx, x, y, width, height, from_line_num, min_x, false, .normal, BufferCursor{})
 
 	// TODO(tauraamui) [14/04/2025]: need to assert against style draws as well
+	assert set_bg_color == [draw.Color{ 53, 53, 53 }, draw.Color{ 53, 53, 53 }]
 	assert drawn_rect == [
 		DrawnRect{ x: 2, y: 0, width: 13, height: 1 }
 	]
 
 	assert drawn_text.len == 24
 	assert set_fg_color.len == 24
+
+	// this is the line at the side being rendered
+	assert set_fg_color[0] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[1])? == .number
+	assert syntax.color_to_type(set_fg_color[2])? == .identifier
+	assert syntax.color_to_type(set_fg_color[3])? == .identifier
+	assert syntax.color_to_type(set_fg_color[4])? == .identifier
+	assert syntax.color_to_type(set_fg_color[5])? == .identifier
+	assert syntax.color_to_type(set_fg_color[6])? == .identifier
+	assert syntax.color_to_type(set_fg_color[7])? == .identifier
+
+	// this is the line at the side being rendered
+	assert set_fg_color[8] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[9])? == .number
+	assert syntax.color_to_type(set_fg_color[10])? == .identifier
+	assert syntax.color_to_type(set_fg_color[11])? == .identifier
+	assert syntax.color_to_type(set_fg_color[12])? == .identifier
+	assert syntax.color_to_type(set_fg_color[13])? == .identifier
+	assert syntax.color_to_type(set_fg_color[14])? == .identifier
+	assert syntax.color_to_type(set_fg_color[15])? == .identifier
+
+	// this is the line at the side being rendered
+	assert set_fg_color[16] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[17])? == .number
+	assert syntax.color_to_type(set_fg_color[18])? == .identifier
+	assert syntax.color_to_type(set_fg_color[19])? == .identifier
+	assert syntax.color_to_type(set_fg_color[20])? == .identifier
+	assert syntax.color_to_type(set_fg_color[21])? == .identifier
+	assert syntax.color_to_type(set_fg_color[22])? == .identifier
+	assert syntax.color_to_type(set_fg_color[23])? == .identifier
 
 	line_one_expected_drawn_data := [
 		DrawnText{ x: 0, y: 0, data: "1" }, DT{ x: 2, y: 0, data: "0" }, DT{ x: 3, y: 0, data: " " },
@@ -977,6 +1157,7 @@ mut:
 	on_draw_cb         fn (x int, y int, text string)
 	on_draw_rect_cb    fn (x int, y int, width int, height int)
 	on_set_fg_color_cb fn (c draw.Color)
+	on_set_bg_color_cb fn (c draw.Color)
 }
 
 fn (mockctx MockContextable) render_debug() bool { return false }
@@ -1023,7 +1204,10 @@ fn (mockctx MockContextable) set_color(c draw.Color) {
 	mockctx.on_set_fg_color_cb(c)
 }
 
-fn (mockctx MockContextable) set_bg_color(c draw.Color) {}
+fn (mockctx MockContextable) set_bg_color(c draw.Color) {
+	if mockctx.on_set_bg_color_cb == unsafe { nil } { return }
+	mockctx.on_set_bg_color_cb(c)
+}
 
 fn (mockctx MockContextable) revert_bg_color() {}
 

--- a/src/lib/ui/buffer_view_test.v
+++ b/src/lib/ui/buffer_view_test.v
@@ -1585,6 +1585,9 @@ fn test_buffer_view_draws_lines_0_to_max_height_min_x_21_max_width_6() {
 	mut set_fg_color := []draw.Color{}
 	mut set_fg_color_ref := &set_fg_color
 
+	mut set_bg_color := []draw.Color{}
+	mut set_bg_color_ref := &set_bg_color
+
 	mut drawn_rect := []DrawnRect{}
 	mut drawn_rect_ref := &drawn_rect
 
@@ -1597,6 +1600,9 @@ fn test_buffer_view_draws_lines_0_to_max_height_min_x_21_max_width_6() {
 		}
 		on_set_fg_color_cb: fn [mut set_fg_color_ref] (c draw.Color) {
 			set_fg_color_ref << c
+		}
+		on_set_bg_color_cb: fn [mut set_bg_color_ref] (c draw.Color) {
+			set_bg_color_ref << c
 		}
 	}
 
@@ -1614,12 +1620,29 @@ fn test_buffer_view_draws_lines_0_to_max_height_min_x_21_max_width_6() {
 	buf_view.draw(mut mock_ctx, x, y, width, height, from_line_num, min_x, false, .normal, BufferCursor{})
 
 	// TODO(tauraamui) [14/04/2025]: need to assert against style draws as well
+	assert set_bg_color == [draw.Color{ 53, 53, 53 }, draw.Color{ 53, 53, 53 }]
 	assert drawn_rect == [
 		DrawnRect{ x: 2, y: 0, width: 11, height: 1 }
 	]
 
 	assert drawn_text.len == 12
 	assert set_fg_color.len == 12
+
+	// this is the line at the side being rendered
+	assert set_fg_color[0] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[1])? == .identifier
+	assert syntax.color_to_type(set_fg_color[2])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[3])? == .identifier
+
+	assert set_fg_color[4] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[5])? == .identifier
+	assert syntax.color_to_type(set_fg_color[6])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[7])? == .identifier
+
+	assert set_fg_color[8] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[9])? == .identifier
+	assert syntax.color_to_type(set_fg_color[10])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[11])? == .identifier
 
 	line_one_expected_drawn_data := [
 		DrawnText{ x: 0, y: 0, data: "1" }, DT{ x: 2, y: 0, data: "he" },

--- a/src/lib/ui/buffer_view_test.v
+++ b/src/lib/ui/buffer_view_test.v
@@ -751,6 +751,156 @@ fn test_buffer_view_draws_lines_10_to_max_height_relative_line_numbers_enabled()
 	assert drawn_text.len == 140
 	assert set_fg_color.len == 140
 
+	assert set_fg_color[0] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[1])? == .identifier
+	assert syntax.color_to_type(set_fg_color[2])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[3])? == .identifier
+	assert syntax.color_to_type(set_fg_color[4])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[5])? == .identifier
+	assert syntax.color_to_type(set_fg_color[6])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[7])? == .number
+	assert syntax.color_to_type(set_fg_color[8])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[9])? == .identifier
+	assert syntax.color_to_type(set_fg_color[10])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[11])? == .identifier
+	assert syntax.color_to_type(set_fg_color[12])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[13])? == .identifier
+
+	assert set_fg_color[14] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[15])? == .identifier
+	assert syntax.color_to_type(set_fg_color[16])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[17])? == .identifier
+	assert syntax.color_to_type(set_fg_color[18])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[19])? == .identifier
+	assert syntax.color_to_type(set_fg_color[20])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[21])? == .number
+	assert syntax.color_to_type(set_fg_color[22])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[23])? == .identifier
+	assert syntax.color_to_type(set_fg_color[24])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[25])? == .identifier
+	assert syntax.color_to_type(set_fg_color[26])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[27])? == .identifier
+
+	assert set_fg_color[28] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[29])? == .identifier
+	assert syntax.color_to_type(set_fg_color[30])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[31])? == .identifier
+	assert syntax.color_to_type(set_fg_color[33])? == .identifier
+	assert syntax.color_to_type(set_fg_color[34])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[35])? == .number
+	assert syntax.color_to_type(set_fg_color[36])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[37])? == .identifier
+	assert syntax.color_to_type(set_fg_color[38])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[39])? == .identifier
+	assert syntax.color_to_type(set_fg_color[40])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[41])? == .identifier
+
+	assert set_fg_color[42] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[43])? == .identifier
+	assert syntax.color_to_type(set_fg_color[44])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[45])? == .identifier
+	assert syntax.color_to_type(set_fg_color[46])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[47])? == .identifier
+	assert syntax.color_to_type(set_fg_color[48])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[49])? == .number
+	assert syntax.color_to_type(set_fg_color[50])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[51])? == .identifier
+	assert syntax.color_to_type(set_fg_color[52])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[53])? == .identifier
+	assert syntax.color_to_type(set_fg_color[54])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[55])? == .identifier
+
+	assert set_fg_color[56] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[57])? == .identifier
+	assert syntax.color_to_type(set_fg_color[58])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[59])? == .identifier
+	assert syntax.color_to_type(set_fg_color[60])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[61])? == .identifier
+	assert syntax.color_to_type(set_fg_color[62])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[63])? == .number
+	assert syntax.color_to_type(set_fg_color[64])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[65])? == .identifier
+	assert syntax.color_to_type(set_fg_color[66])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[67])? == .identifier
+	assert syntax.color_to_type(set_fg_color[68])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[69])? == .identifier
+
+	assert set_fg_color[70] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[71])? == .identifier
+	assert syntax.color_to_type(set_fg_color[72])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[73])? == .identifier
+	assert syntax.color_to_type(set_fg_color[74])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[75])? == .identifier
+	assert syntax.color_to_type(set_fg_color[76])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[77])? == .number
+	assert syntax.color_to_type(set_fg_color[78])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[79])? == .identifier
+	assert syntax.color_to_type(set_fg_color[80])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[81])? == .identifier
+	assert syntax.color_to_type(set_fg_color[82])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[83])? == .identifier
+
+	assert set_fg_color[84] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[85])? == .identifier
+	assert syntax.color_to_type(set_fg_color[86])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[87])? == .identifier
+	assert syntax.color_to_type(set_fg_color[88])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[89])? == .identifier
+	assert syntax.color_to_type(set_fg_color[90])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[91])? == .number
+	assert syntax.color_to_type(set_fg_color[92])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[93])? == .identifier
+	assert syntax.color_to_type(set_fg_color[94])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[95])? == .identifier
+	assert syntax.color_to_type(set_fg_color[96])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[97])? == .identifier
+
+	assert set_fg_color[98] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[99])? == .identifier
+	assert syntax.color_to_type(set_fg_color[100])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[101])? == .identifier
+	assert syntax.color_to_type(set_fg_color[102])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[103])? == .identifier
+	assert syntax.color_to_type(set_fg_color[104])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[105])? == .number
+	assert syntax.color_to_type(set_fg_color[106])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[107])? == .identifier
+	assert syntax.color_to_type(set_fg_color[108])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[109])? == .identifier
+	assert syntax.color_to_type(set_fg_color[110])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[111])? == .identifier
+
+	assert set_fg_color[112] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[113])? == .identifier
+	assert syntax.color_to_type(set_fg_color[114])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[115])? == .identifier
+	assert syntax.color_to_type(set_fg_color[116])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[117])? == .identifier
+	assert syntax.color_to_type(set_fg_color[118])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[119])? == .number
+	assert syntax.color_to_type(set_fg_color[120])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[121])? == .identifier
+	assert syntax.color_to_type(set_fg_color[122])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[123])? == .identifier
+	assert syntax.color_to_type(set_fg_color[124])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[125])? == .identifier
+
+	assert set_fg_color[126] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[127])? == .identifier
+	assert syntax.color_to_type(set_fg_color[127])? == .identifier
+	assert syntax.color_to_type(set_fg_color[128])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[129])? == .identifier
+	assert syntax.color_to_type(set_fg_color[130])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[131])? == .identifier
+	assert syntax.color_to_type(set_fg_color[132])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[133])? == .number
+	assert syntax.color_to_type(set_fg_color[134])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[135])? == .identifier
+	assert syntax.color_to_type(set_fg_color[136])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[137])? == .identifier
+	assert syntax.color_to_type(set_fg_color[138])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[139])? == .identifier
+
 	line_one_expected_drawn_data := [
 		DrawnText{ x: 1, y: 0, data: "5" }, DrawnText{ x: 3, y: 0, data: "This" },
 		DrawnText{ x: 7, y: 0, data: " " }, DrawnText{ x: 8, y: 0, data: "is" },
@@ -869,6 +1019,9 @@ fn test_buffer_view_draws_lines_10_to_max_height_relative_line_numbers_enabled_c
 	mut set_fg_color := []draw.Color{}
 	mut set_fg_color_ref := &set_fg_color
 
+	mut set_bg_color := []draw.Color{}
+	mut set_bg_color_ref := &set_bg_color
+
 	mut drawn_rect := []DrawnRect{}
 	mut drawn_rect_ref := &drawn_rect
 
@@ -881,6 +1034,9 @@ fn test_buffer_view_draws_lines_10_to_max_height_relative_line_numbers_enabled_c
 		}
 		on_set_fg_color_cb: fn [mut set_fg_color_ref] (c draw.Color) {
 			set_fg_color_ref << c
+		}
+		on_set_bg_color_cb: fn [mut set_bg_color_ref] (c draw.Color) {
+			set_bg_color_ref << c
 		}
 	}
 
@@ -902,12 +1058,28 @@ fn test_buffer_view_draws_lines_10_to_max_height_relative_line_numbers_enabled_c
 	) // toggle relative line numbers on
 
 	// TODO(tauraamui) [14/04/2025]: need to assert against style draws as well
+	assert set_bg_color == [draw.Color{ 53, 53, 53 }, draw.Color{ 53, 53, 53 }]
 	assert drawn_rect == [
 		DrawnRect{ x: 3, y: 5, width: 98, height: 1 }
 	]
 
 	assert drawn_text.len == 140
 	assert set_fg_color.len == 140
+
+	assert set_fg_color[0] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[1])? == .identifier
+	assert syntax.color_to_type(set_fg_color[2])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[3])? == .identifier
+	assert syntax.color_to_type(set_fg_color[4])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[5])? == .identifier
+	assert syntax.color_to_type(set_fg_color[6])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[7])? == .number
+	assert syntax.color_to_type(set_fg_color[8])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[9])? == .identifier
+	assert syntax.color_to_type(set_fg_color[10])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[11])? == .identifier
+	assert syntax.color_to_type(set_fg_color[12])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[13])? == .identifier
 
 	assert drawn_text[0] == DrawnText{ x: 1, y: 0, data: "5" }
 	assert drawn_text[14] == DrawnText{ x: 1, y: 1, data: "4" }

--- a/src/lib/ui/buffer_view_test.v
+++ b/src/lib/ui/buffer_view_test.v
@@ -74,7 +74,7 @@ fn test_buffer_view_draws_lines_0_to_max_height() {
 	buf_view.draw(
 		mut mock_ctx, x, y,
 		width, height, from_line_num,
-		min_x, false, .normal, BufferCursor{}
+		min_x, false, .normal, BufferCursor{}, draw.Color{ 111, 0, 0 }
 	)
 
 	assert set_bg_color == [draw.Color{ 53, 53, 53 }, draw.Color{ 53, 53, 53 }]
@@ -222,7 +222,7 @@ fn test_buffer_view_draws_1_line_as_single_segment_that_that_elapses_max_width()
 	buf_view.draw(
 		mut mock_ctx, x, y,
 		width, height, from_line_num,
-		min_x, false, .normal, BufferCursor{}
+		min_x, false, .normal, BufferCursor{}, draw.Color{ 111, 0, 0 }
 	)
 
 	assert set_bg_color == [draw.Color{ 53, 53, 53 }, draw.Color{ 53, 53, 53 }]
@@ -284,7 +284,7 @@ fn test_buffer_view_draws_1_line_as_multiple_segments_highlighted_as_expected() 
 	buf_view.draw(
 		mut mock_ctx, x, y,
 		width, height, from_line_num,
-		min_x, false, .normal, BufferCursor{}
+		min_x, false, .normal, BufferCursor{}, draw.Color{ 111, 0, 0 }
 	)
 
 	assert set_bg_color == [draw.Color{ 53, 53, 53 }, draw.Color{ 53, 53, 53 }]
@@ -357,7 +357,7 @@ fn test_buffer_view_draws_1_line_as_single_segment_single_emoji() {
 	buf_view.draw(
 		mut mock_ctx, x, y,
 		width, height, from_line_num,
-		min_x, false, .normal, BufferCursor{}
+		min_x, false, .normal, BufferCursor{}, draw.Color{ 111, 0, 0 }
 	)
 
 	assert set_bg_color == [draw.Color{ 53, 53, 53 }, draw.Color{ 53, 53, 53 }]
@@ -420,7 +420,7 @@ fn test_buffer_view_draws_lines_10_to_max_height() {
 	buf_view.draw(
 		mut mock_ctx, x, y,
 		width, height, from_line_num,
-		min_x, false, .normal, BufferCursor{ pos: CursorPos{ y: 12 } }
+		min_x, false, .normal, BufferCursor{ pos: CursorPos{ y: 12 } }, draw.Color{ 111, 0, 0 }
 	)
 
 	assert set_bg_color == [draw.Color{ 53, 53, 53 }, draw.Color{ 53, 53, 53 }]
@@ -734,7 +734,7 @@ fn test_buffer_view_draws_lines_10_to_max_height_relative_line_numbers_enabled()
 	buf_view.draw(
 		mut mock_ctx, x, y,
 		width, height, from_line_num,
-		min_x, true, .normal, BufferCursor{ pos: CursorPos{ y: 15 } }
+		min_x, true, .normal, BufferCursor{ pos: CursorPos{ y: 15 } }, draw.Color{ 111, 0, 0 }
 	) // toggle relative line numbers on
 
 	assert set_bg_color == [draw.Color{ 53, 53, 53 }, draw.Color{ 53, 53, 53 }]
@@ -1048,7 +1048,7 @@ fn test_buffer_view_draws_lines_10_to_max_height_relative_line_numbers_enabled_c
 	buf_view.draw(
 		mut mock_ctx, x, y,
 		width, height, from_line_num,
-		min_x, true, .normal, BufferCursor{ pos: CursorPos{ y: 15 } }
+		min_x, true, .normal, BufferCursor{ pos: CursorPos{ y: 15 } }, draw.Color{ 111, 0, 0 }
 	) // toggle relative line numbers on
 
 	assert set_bg_color == [draw.Color{ 53, 53, 53 }, draw.Color{ 53, 53, 53 }]
@@ -1224,7 +1224,7 @@ fn test_buffer_view_draws_lines_10_to_max_height_relative_line_numbers_enabled_c
 	buf_view.draw(
 		mut mock_ctx, x, y,
 		width, height, from_line_num,
-		min_x, true, .normal, BufferCursor{ pos: CursorPos{ y: 13 } }
+		min_x, true, .normal, BufferCursor{ pos: CursorPos{ y: 13 } }, draw.Color{ 111, 0, 0 }
 	) // toggle relative line numbers on
 
 	assert drawn_text[0] == DrawnText{ x: 1, y: 0, data: "3" }
@@ -1243,7 +1243,8 @@ fn test_buffer_view_draws_lines_10_to_max_height_relative_line_numbers_enabled_c
 		mut mock_ctx, x, y,
 		width, height, from_line_num,
 		min_x, true, .normal,
-		BufferCursor{ pos: CursorPos{ y: 18 } }
+		BufferCursor{ pos: CursorPos{ y: 18 } },
+		draw.Color{ 111, 0, 0 }
 	) // toggle relative line numbers on
 
 	assert drawn_text[0] == DrawnText{ x: 1, y: 0, data: "8" }
@@ -1299,7 +1300,7 @@ fn test_buffer_view_draws_lines_0_to_max_height_min_x_0_max_width_14() {
 	min_x := 0
 	from_line_num := 0
 
-	buf_view.draw(mut mock_ctx, x, y, width, height, from_line_num, min_x, false, .normal, BufferCursor{})
+	buf_view.draw(mut mock_ctx, x, y, width, height, from_line_num, min_x, false, .normal, BufferCursor{}, draw.Color{ 111, 0, 0 })
 
 	assert set_bg_color == [draw.Color{ 53, 53, 53 }, draw.Color{ 53, 53, 53 }]
 	assert drawn_rect == [
@@ -1400,7 +1401,7 @@ fn test_buffer_view_draws_lines_0_to_max_height_min_x_4_max_width_56() {
 	min_x := 4
 	from_line_num := 0
 
-	buf_view.draw(mut mock_ctx, x, y, width, height, from_line_num, min_x, false, .normal, BufferCursor{})
+	buf_view.draw(mut mock_ctx, x, y, width, height, from_line_num, min_x, false, .normal, BufferCursor{}, draw.Color{ 111, 0, 0 })
 
 	assert set_bg_color == [draw.Color{ 53, 53, 53 }, draw.Color{ 53, 53, 53 }]
 	assert drawn_rect == [
@@ -1523,7 +1524,7 @@ fn test_buffer_view_draws_lines_0_to_max_height_min_x_21_max_width_56() {
 	min_x := 21
 	from_line_num := 0
 
-	buf_view.draw(mut mock_ctx, x, y, width, height, from_line_num, min_x, false, .normal, BufferCursor{})
+	buf_view.draw(mut mock_ctx, x, y, width, height, from_line_num, min_x, false, .normal, BufferCursor{}, draw.Color{ 111, 0, 0 })
 
 	assert set_bg_color == [draw.Color{ 53, 53, 53 }, draw.Color{ 53, 53, 53 }]
 	assert drawn_rect == [
@@ -1607,7 +1608,7 @@ fn test_buffer_view_draws_lines_0_to_max_height_min_x_21_max_width_6() {
 	min_x := 21
 	from_line_num := 0
 
-	buf_view.draw(mut mock_ctx, x, y, width, height, from_line_num, min_x, false, .normal, BufferCursor{})
+	buf_view.draw(mut mock_ctx, x, y, width, height, from_line_num, min_x, false, .normal, BufferCursor{}, draw.Color{ 111, 0, 0 })
 
 	assert set_bg_color == [draw.Color{ 53, 53, 53 }, draw.Color{ 53, 53, 53 }]
 	assert drawn_rect == [

--- a/src/lib/ui/buffer_view_test.v
+++ b/src/lib/ui/buffer_view_test.v
@@ -494,19 +494,32 @@ fn test_buffer_view_draws_lines_10_to_max_height() {
 	assert syntax.color_to_type(set_fg_color[53])? == .identifier
 	assert syntax.color_to_type(set_fg_color[54])? == .whitespace
 
-	assert set_fg_color[55] == line_num_fg_color
-	assert syntax.color_to_type(set_fg_color[56])? == .identifier
-	assert syntax.color_to_type(set_fg_color[57])? == .whitespace
-	assert syntax.color_to_type(set_fg_color[58])? == .identifier
-	assert syntax.color_to_type(set_fg_color[59])? == .whitespace
-	assert syntax.color_to_type(set_fg_color[60])? == .identifier
-	assert syntax.color_to_type(set_fg_color[61])? == .whitespace
-	assert syntax.color_to_type(set_fg_color[62])? == .number
-	assert syntax.color_to_type(set_fg_color[63])? == .whitespace
-	assert syntax.color_to_type(set_fg_color[64])? == .identifier
-	assert syntax.color_to_type(set_fg_color[65])? == .whitespace
-	assert syntax.color_to_type(set_fg_color[66])? == .identifier
-	assert syntax.color_to_type(set_fg_color[67])? == .whitespace
+	assert set_fg_color[55] == draw.Color{ 231, 231, 231 } // TODO(tauraamui) [10/06/2025]: figure out where this specific colour is coming from
+	assert set_fg_color[56] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[57])? == .identifier
+	assert syntax.color_to_type(set_fg_color[58])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[59])? == .identifier
+	assert syntax.color_to_type(set_fg_color[60])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[61])? == .identifier
+	assert syntax.color_to_type(set_fg_color[62])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[63])? == .number
+	assert syntax.color_to_type(set_fg_color[64])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[65])? == .identifier
+	assert syntax.color_to_type(set_fg_color[66])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[67])? == .identifier
+
+	assert set_fg_color[68] == draw.Color{ 107, 189, 21 } // TODO(tauraamui) [10/06/2025]: figure out where this specific colour is coming from
+	assert syntax.color_to_type(set_fg_color[69])? == .identifier
+	assert set_fg_color[70] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[71])? == .identifier
+	assert syntax.color_to_type(set_fg_color[72])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[73])? == .identifier
+	assert syntax.color_to_type(set_fg_color[74])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[75])? == .identifier
+	assert syntax.color_to_type(set_fg_color[76])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[77])? == .number
+	assert syntax.color_to_type(set_fg_color[78])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[79])? == .identifier
 
 	line_one_expected_drawn_data := [
 		DrawnText{ x: 0, y: 0, data: "11" }, DrawnText{ x: 3, y: 0, data: "This" },
@@ -626,6 +639,9 @@ fn test_buffer_view_draws_lines_10_to_max_height_relative_line_numbers_enabled()
 	mut set_fg_color := []draw.Color{}
 	mut set_fg_color_ref := &set_fg_color
 
+	mut set_bg_color := []draw.Color{}
+	mut set_bg_color_ref := &set_bg_color
+
 	mut drawn_rect := []DrawnRect{}
 	mut drawn_rect_ref := &drawn_rect
 
@@ -638,6 +654,9 @@ fn test_buffer_view_draws_lines_10_to_max_height_relative_line_numbers_enabled()
 		}
 		on_set_fg_color_cb: fn [mut set_fg_color_ref] (c draw.Color) {
 			set_fg_color_ref << c
+		}
+		on_set_bg_color_cb: fn [mut set_bg_color_ref] (c draw.Color) {
+			set_bg_color_ref << c
 		}
 	}
 
@@ -659,6 +678,7 @@ fn test_buffer_view_draws_lines_10_to_max_height_relative_line_numbers_enabled()
 	) // toggle relative line numbers on
 
 	// TODO(tauraamui) [14/04/2025]: need to assert against style draws as well
+	assert set_bg_color == [draw.Color{ 53, 53, 53 }, draw.Color{ 53, 53, 53 }]
 	assert drawn_rect == [
 		DrawnRect{ x: 3, y: 5, width: 98, height: 1 }
 	]

--- a/src/lib/ui/buffer_view_test.v
+++ b/src/lib/ui/buffer_view_test.v
@@ -1376,6 +1376,9 @@ fn test_buffer_view_draws_lines_0_to_max_height_min_x_4_max_width_56() {
 	mut set_fg_color := []draw.Color{}
 	mut set_fg_color_ref := &set_fg_color
 
+	mut set_bg_color := []draw.Color{}
+	mut set_bg_color_ref := &set_bg_color
+
 	mut drawn_rect := []DrawnRect{}
 	mut drawn_rect_ref := &drawn_rect
 
@@ -1388,6 +1391,9 @@ fn test_buffer_view_draws_lines_0_to_max_height_min_x_4_max_width_56() {
 		}
 		on_set_fg_color_cb: fn [mut set_fg_color_ref] (c draw.Color) {
 			set_fg_color_ref << c
+		}
+		on_set_bg_color_cb: fn [mut set_bg_color_ref] (c draw.Color) {
+			set_bg_color_ref << c
 		}
 	}
 
@@ -1405,12 +1411,44 @@ fn test_buffer_view_draws_lines_0_to_max_height_min_x_4_max_width_56() {
 	buf_view.draw(mut mock_ctx, x, y, width, height, from_line_num, min_x, false, .normal, BufferCursor{})
 
 	// TODO(tauraamui) [14/04/2025]: need to assert against style draws as well
+	assert set_bg_color == [draw.Color{ 53, 53, 53 }, draw.Color{ 53, 53, 53 }]
 	assert drawn_rect == [
 		DrawnRect{ x: 2, y: 0, width: 55, height: 1 }
 	]
 
 	assert drawn_text.len == 42
 	assert set_fg_color.len == 42
+
+	// this is the line at the side being rendered
+	assert set_fg_color[0] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[1])? == .identifier
+	assert syntax.color_to_type(set_fg_color[2])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[3])? == .identifier
+	assert syntax.color_to_type(set_fg_color[4])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[5])? == .identifier
+	assert syntax.color_to_type(set_fg_color[6])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[7])? == .number
+	assert syntax.color_to_type(set_fg_color[8])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[9])? == .identifier
+	assert syntax.color_to_type(set_fg_color[10])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[11])? == .identifier
+	assert syntax.color_to_type(set_fg_color[12])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[13])? == .identifier
+
+	assert set_fg_color[14] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[15])? == .identifier
+	assert syntax.color_to_type(set_fg_color[16])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[17])? == .identifier
+	assert syntax.color_to_type(set_fg_color[18])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[19])? == .identifier
+	assert syntax.color_to_type(set_fg_color[20])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[21])? == .number
+	assert syntax.color_to_type(set_fg_color[22])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[23])? == .identifier
+	assert syntax.color_to_type(set_fg_color[24])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[25])? == .identifier
+	assert syntax.color_to_type(set_fg_color[26])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[27])? == .identifier
 
 	line_one_expected_drawn_data := [
 		DrawnText{ x: 0, y: 0, data: "1" }, DT{ x: 2, y: 0, data: "is" }, DT{ x: 4, y: 0, data: " " },

--- a/src/lib/ui/buffer_view_test.v
+++ b/src/lib/ui/buffer_view_test.v
@@ -1450,6 +1450,21 @@ fn test_buffer_view_draws_lines_0_to_max_height_min_x_4_max_width_56() {
 	assert syntax.color_to_type(set_fg_color[26])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[27])? == .identifier
 
+	assert set_fg_color[28] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[29])? == .identifier
+	assert syntax.color_to_type(set_fg_color[30])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[31])? == .identifier
+	assert syntax.color_to_type(set_fg_color[32])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[33])? == .identifier
+	assert syntax.color_to_type(set_fg_color[34])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[35])? == .number
+	assert syntax.color_to_type(set_fg_color[36])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[37])? == .identifier
+	assert syntax.color_to_type(set_fg_color[38])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[39])? == .identifier
+	assert syntax.color_to_type(set_fg_color[40])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[41])? == .identifier
+
 	line_one_expected_drawn_data := [
 		DrawnText{ x: 0, y: 0, data: "1" }, DT{ x: 2, y: 0, data: "is" }, DT{ x: 4, y: 0, data: " " },
 		DT{ x: 5, y: 0, data: "is" }, DT{ x: 7, y: 0, data: " " }, DT{ x: 8, y: 0, data: "line" },

--- a/src/lib/ui/buffer_view_test.v
+++ b/src/lib/ui/buffer_view_test.v
@@ -534,6 +534,19 @@ fn test_buffer_view_draws_lines_10_to_max_height() {
 	assert syntax.color_to_type(set_fg_color[90])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[91])? == .number
 
+	assert set_fg_color[92] == draw.Color{ 107, 189, 21 } // TODO(tauraamui) [10/06/2025]: figure out where this specific colour is coming from
+	assert syntax.color_to_type(set_fg_color[93])? == .identifier
+	assert syntax.color_to_type(set_fg_color[94])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[95])? == .identifier
+	assert set_fg_color[96] == draw.Color{ 107, 189, 21 } // TODO(tauraamui) [10/06/2025]: figure out where this specific colour is coming from
+	assert syntax.color_to_type(set_fg_color[97])? == .identifier
+	assert set_fg_color[98] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[99])? == .identifier
+	assert syntax.color_to_type(set_fg_color[100])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[101])? == .identifier
+	assert syntax.color_to_type(set_fg_color[102])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[103])? == .identifier
+
 	line_one_expected_drawn_data := [
 		DrawnText{ x: 0, y: 0, data: "11" }, DrawnText{ x: 3, y: 0, data: "This" },
 		DrawnText{ x: 7, y: 0, data: " " }, DrawnText{ x: 8, y: 0, data: "is" },

--- a/src/lib/ui/buffer_view_test.v
+++ b/src/lib/ui/buffer_view_test.v
@@ -493,8 +493,8 @@ fn test_buffer_view_draws_lines_10_to_max_height() {
 	assert syntax.color_to_type(set_fg_color[52])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[53])? == .identifier
 	assert syntax.color_to_type(set_fg_color[54])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[55])? == .identifier
 
-	assert set_fg_color[55] == draw.Color{ 231, 231, 231 } // TODO(tauraamui) [10/06/2025]: figure out where this specific colour is coming from
 	assert set_fg_color[56] == line_num_fg_color
 	assert syntax.color_to_type(set_fg_color[57])? == .identifier
 	assert syntax.color_to_type(set_fg_color[58])? == .whitespace
@@ -507,9 +507,9 @@ fn test_buffer_view_draws_lines_10_to_max_height() {
 	assert syntax.color_to_type(set_fg_color[65])? == .identifier
 	assert syntax.color_to_type(set_fg_color[66])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[67])? == .identifier
-
-	assert set_fg_color[68] == draw.Color{ 107, 189, 21 } // TODO(tauraamui) [10/06/2025]: figure out where this specific colour is coming from
+	assert syntax.color_to_type(set_fg_color[68])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[69])? == .identifier
+
 	assert set_fg_color[70] == line_num_fg_color
 	assert syntax.color_to_type(set_fg_color[71])? == .identifier
 	assert syntax.color_to_type(set_fg_color[72])? == .whitespace
@@ -520,11 +520,11 @@ fn test_buffer_view_draws_lines_10_to_max_height() {
 	assert syntax.color_to_type(set_fg_color[77])? == .number
 	assert syntax.color_to_type(set_fg_color[78])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[79])? == .identifier
-
-	assert set_fg_color[80] == draw.Color{ 107, 189, 21 } // TODO(tauraamui) [10/06/2025]: figure out where this specific colour is coming from
+	assert syntax.color_to_type(set_fg_color[80])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[81])? == .identifier
 	assert syntax.color_to_type(set_fg_color[82])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[83])? == .identifier
+
 	assert set_fg_color[84] == line_num_fg_color
 	assert syntax.color_to_type(set_fg_color[85])? == .identifier
 	assert syntax.color_to_type(set_fg_color[86])? == .whitespace
@@ -533,19 +533,58 @@ fn test_buffer_view_draws_lines_10_to_max_height() {
 	assert syntax.color_to_type(set_fg_color[89])? == .identifier
 	assert syntax.color_to_type(set_fg_color[90])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[91])? == .number
-
-	assert set_fg_color[92] == draw.Color{ 107, 189, 21 } // TODO(tauraamui) [10/06/2025]: figure out where this specific colour is coming from
+	assert syntax.color_to_type(set_fg_color[92])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[93])? == .identifier
 	assert syntax.color_to_type(set_fg_color[94])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[95])? == .identifier
-	assert set_fg_color[96] == draw.Color{ 107, 189, 21 } // TODO(tauraamui) [10/06/2025]: figure out where this specific colour is coming from
+	assert syntax.color_to_type(set_fg_color[96])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[97])? == .identifier
+
 	assert set_fg_color[98] == line_num_fg_color
 	assert syntax.color_to_type(set_fg_color[99])? == .identifier
 	assert syntax.color_to_type(set_fg_color[100])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[101])? == .identifier
 	assert syntax.color_to_type(set_fg_color[102])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[103])? == .identifier
+	assert syntax.color_to_type(set_fg_color[104])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[105])? == .number
+	assert syntax.color_to_type(set_fg_color[106])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[107])? == .identifier
+	assert syntax.color_to_type(set_fg_color[108])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[109])? == .identifier
+	assert syntax.color_to_type(set_fg_color[110])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[111])? == .identifier
+
+	assert set_fg_color[112] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[113])? == .identifier
+	assert syntax.color_to_type(set_fg_color[114])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[115])? == .identifier
+	assert syntax.color_to_type(set_fg_color[116])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[117])? == .identifier
+	assert syntax.color_to_type(set_fg_color[118])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[119])? == .number
+	assert syntax.color_to_type(set_fg_color[120])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[121])? == .identifier
+	assert syntax.color_to_type(set_fg_color[122])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[123])? == .identifier
+	assert syntax.color_to_type(set_fg_color[124])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[125])? == .identifier
+
+	assert set_fg_color[126] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[127])? == .identifier
+	assert syntax.color_to_type(set_fg_color[127])? == .identifier
+	assert syntax.color_to_type(set_fg_color[128])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[129])? == .identifier
+	assert syntax.color_to_type(set_fg_color[130])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[131])? == .identifier
+	assert syntax.color_to_type(set_fg_color[132])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[133])? == .number
+	assert syntax.color_to_type(set_fg_color[134])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[135])? == .identifier
+	assert syntax.color_to_type(set_fg_color[136])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[137])? == .identifier
+	assert syntax.color_to_type(set_fg_color[138])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[139])? == .identifier
 
 	line_one_expected_drawn_data := [
 		DrawnText{ x: 0, y: 0, data: "11" }, DrawnText{ x: 3, y: 0, data: "This" },

--- a/src/lib/ui/buffer_view_test.v
+++ b/src/lib/ui/buffer_view_test.v
@@ -88,62 +88,62 @@ fn test_buffer_view_draws_lines_0_to_max_height() {
 	// this is the line at the side being rendered
 	assert set_fg_color[0] == line_num_fg_color
 	assert syntax.color_to_type(set_fg_color[1])? == .identifier
-	assert syntax.color_to_type(set_fg_color[2])? == .identifier
+	assert syntax.color_to_type(set_fg_color[2])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[3])? == .identifier
-	assert syntax.color_to_type(set_fg_color[4])? == .identifier
+	assert syntax.color_to_type(set_fg_color[4])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[5])? == .identifier
-	assert syntax.color_to_type(set_fg_color[6])? == .identifier
+	assert syntax.color_to_type(set_fg_color[6])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[7])? == .number
-	assert syntax.color_to_type(set_fg_color[8])? == .identifier
+	assert syntax.color_to_type(set_fg_color[8])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[9])? == .identifier
-	assert syntax.color_to_type(set_fg_color[10])? == .identifier
+	assert syntax.color_to_type(set_fg_color[10])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[11])? == .identifier
-	assert syntax.color_to_type(set_fg_color[12])? == .identifier
+	assert syntax.color_to_type(set_fg_color[12])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[13])? == .identifier
 
 	assert set_fg_color[14] == line_num_fg_color
 	assert syntax.color_to_type(set_fg_color[15])? == .identifier
-	assert syntax.color_to_type(set_fg_color[16])? == .identifier
+	assert syntax.color_to_type(set_fg_color[16])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[17])? == .identifier
-	assert syntax.color_to_type(set_fg_color[18])? == .identifier
+	assert syntax.color_to_type(set_fg_color[18])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[19])? == .identifier
-	assert syntax.color_to_type(set_fg_color[20])? == .identifier
+	assert syntax.color_to_type(set_fg_color[20])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[21])? == .number
-	assert syntax.color_to_type(set_fg_color[22])? == .identifier
+	assert syntax.color_to_type(set_fg_color[22])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[23])? == .identifier
-	assert syntax.color_to_type(set_fg_color[24])? == .identifier
+	assert syntax.color_to_type(set_fg_color[24])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[25])? == .identifier
-	assert syntax.color_to_type(set_fg_color[26])? == .identifier
+	assert syntax.color_to_type(set_fg_color[26])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[27])? == .identifier
 
 	assert set_fg_color[28] == line_num_fg_color
 	assert syntax.color_to_type(set_fg_color[29])? == .identifier
-	assert syntax.color_to_type(set_fg_color[30])? == .identifier
+	assert syntax.color_to_type(set_fg_color[30])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[31])? == .identifier
-	assert syntax.color_to_type(set_fg_color[32])? == .identifier
+	assert syntax.color_to_type(set_fg_color[32])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[33])? == .identifier
-	assert syntax.color_to_type(set_fg_color[34])? == .identifier
+	assert syntax.color_to_type(set_fg_color[34])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[35])? == .number
-	assert syntax.color_to_type(set_fg_color[36])? == .identifier
+	assert syntax.color_to_type(set_fg_color[36])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[37])? == .identifier
-	assert syntax.color_to_type(set_fg_color[38])? == .identifier
+	assert syntax.color_to_type(set_fg_color[38])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[39])? == .identifier
-	assert syntax.color_to_type(set_fg_color[40])? == .identifier
+	assert syntax.color_to_type(set_fg_color[40])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[41])? == .identifier
 
 	assert set_fg_color[42] == line_num_fg_color
 	assert syntax.color_to_type(set_fg_color[43])? == .identifier
-	assert syntax.color_to_type(set_fg_color[44])? == .identifier
+	assert syntax.color_to_type(set_fg_color[44])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[45])? == .identifier
-	assert syntax.color_to_type(set_fg_color[46])? == .identifier
+	assert syntax.color_to_type(set_fg_color[46])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[47])? == .identifier
-	assert syntax.color_to_type(set_fg_color[48])? == .identifier
+	assert syntax.color_to_type(set_fg_color[48])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[49])? == .number
-	assert syntax.color_to_type(set_fg_color[50])? == .identifier
+	assert syntax.color_to_type(set_fg_color[50])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[51])? == .identifier
-	assert syntax.color_to_type(set_fg_color[52])? == .identifier
+	assert syntax.color_to_type(set_fg_color[52])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[53])? == .identifier
-	assert syntax.color_to_type(set_fg_color[54])? == .identifier
+	assert syntax.color_to_type(set_fg_color[54])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[55])? == .identifier
 
 	// TODO(tauraamui) [14/04/2025]: need to assert against style draws as well
@@ -300,13 +300,13 @@ fn test_buffer_view_draws_1_line_as_multiple_segments_highlighted_as_expected() 
 
 	assert set_fg_color[0] == line_num_fg_color
 	assert syntax.color_to_type(set_fg_color[1])? == .identifier
-	assert syntax.color_to_type(set_fg_color[2])? == .identifier
+	assert syntax.color_to_type(set_fg_color[2])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[3])? == .identifier
-	assert syntax.color_to_type(set_fg_color[4])? == .identifier
+	assert syntax.color_to_type(set_fg_color[4])? == .other
 	assert syntax.color_to_type(set_fg_color[5])? == .identifier
-	assert syntax.color_to_type(set_fg_color[6])? == .identifier
+	assert syntax.color_to_type(set_fg_color[6])? == .other
 	assert syntax.color_to_type(set_fg_color[7])? == .identifier
-	assert syntax.color_to_type(set_fg_color[8])? == .identifier
+	assert syntax.color_to_type(set_fg_color[8])? == .other
 
 	line_one_expected_drawn_data := [
 		DrawnText{ x: 0, y: 0, data: "1" }, DrawnText{ x: 2, y: 0, data: "fn" },
@@ -373,7 +373,7 @@ fn test_buffer_view_draws_1_line_as_single_segment_single_emoji() {
 	assert set_fg_color.len == 2
 
 	assert set_fg_color[0] == line_num_fg_color
-	assert syntax.color_to_type(set_fg_color[1])? == .identifier
+	assert syntax.color_to_type(set_fg_color[1])? == .other
 
 	line_one_expected_drawn_data := [
 		DrawnText{ x: 0, y: 0, data: "1" }, DrawnText{ x: 2, y: 0, data: "${utf8.emoji_shark_char}" },
@@ -438,33 +438,47 @@ fn test_buffer_view_draws_lines_10_to_max_height() {
 
 	assert set_fg_color[0] == line_num_fg_color
 	assert syntax.color_to_type(set_fg_color[1])? == .identifier
-	assert syntax.color_to_type(set_fg_color[2])? == .identifier
+	assert syntax.color_to_type(set_fg_color[2])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[3])? == .identifier
-	assert syntax.color_to_type(set_fg_color[4])? == .identifier
+	assert syntax.color_to_type(set_fg_color[4])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[5])? == .identifier
-	assert syntax.color_to_type(set_fg_color[6])? == .identifier
+	assert syntax.color_to_type(set_fg_color[6])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[7])? == .number
-	assert syntax.color_to_type(set_fg_color[8])? == .identifier
+	assert syntax.color_to_type(set_fg_color[8])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[9])? == .identifier
-	assert syntax.color_to_type(set_fg_color[10])? == .identifier
+	assert syntax.color_to_type(set_fg_color[10])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[11])? == .identifier
-	assert syntax.color_to_type(set_fg_color[12])? == .identifier
+	assert syntax.color_to_type(set_fg_color[12])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[13])? == .identifier
 
 	assert set_fg_color[14] == line_num_fg_color
 	assert syntax.color_to_type(set_fg_color[15])? == .identifier
-	assert syntax.color_to_type(set_fg_color[16])? == .identifier
+	assert syntax.color_to_type(set_fg_color[16])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[17])? == .identifier
-	assert syntax.color_to_type(set_fg_color[18])? == .identifier
+	assert syntax.color_to_type(set_fg_color[18])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[19])? == .identifier
-	assert syntax.color_to_type(set_fg_color[20])? == .identifier
+	assert syntax.color_to_type(set_fg_color[20])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[21])? == .number
-	assert syntax.color_to_type(set_fg_color[22])? == .identifier
+	assert syntax.color_to_type(set_fg_color[22])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[23])? == .identifier
-	assert syntax.color_to_type(set_fg_color[24])? == .identifier
+	assert syntax.color_to_type(set_fg_color[24])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[25])? == .identifier
-	assert syntax.color_to_type(set_fg_color[26])? == .identifier
+	assert syntax.color_to_type(set_fg_color[26])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[27])? == .identifier
+
+	assert set_fg_color[28] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[29])? == .identifier
+	assert syntax.color_to_type(set_fg_color[30])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[31])? == .identifier
+	assert syntax.color_to_type(set_fg_color[33])? == .identifier
+	assert syntax.color_to_type(set_fg_color[34])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[35])? == .number
+	assert syntax.color_to_type(set_fg_color[36])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[37])? == .identifier
+	assert syntax.color_to_type(set_fg_color[38])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[39])? == .identifier
+	assert syntax.color_to_type(set_fg_color[40])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[41])? == .identifier
 
 	line_one_expected_drawn_data := [
 		DrawnText{ x: 0, y: 0, data: "11" }, DrawnText{ x: 3, y: 0, data: "This" },
@@ -886,11 +900,11 @@ fn test_buffer_view_draws_lines_0_to_max_height_min_x_0_max_width_14() {
 	// this is the line at the side being rendered
 	assert set_fg_color[0] == line_num_fg_color
 	assert syntax.color_to_type(set_fg_color[1])? == .number
-	assert syntax.color_to_type(set_fg_color[2])? == .identifier
+	assert syntax.color_to_type(set_fg_color[2])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[3])? == .identifier
-	assert syntax.color_to_type(set_fg_color[4])? == .identifier
+	assert syntax.color_to_type(set_fg_color[4])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[5])? == .identifier
-	assert syntax.color_to_type(set_fg_color[6])? == .identifier
+	assert syntax.color_to_type(set_fg_color[6])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[7])? == .identifier
 
 	// this is the line at the side being rendered

--- a/src/lib/ui/buffer_view_test.v
+++ b/src/lib/ui/buffer_view_test.v
@@ -146,7 +146,6 @@ fn test_buffer_view_draws_lines_0_to_max_height() {
 	assert syntax.color_to_type(set_fg_color[54])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[55])? == .identifier
 
-	// TODO(tauraamui) [14/04/2025]: need to assert against style draws as well
 	line_one_expected_drawn_data := [
 		DrawnText{ x: 0, y: 0, data: "1" }, DrawnText{ x: 2, y: 0, data: "This" },
 		DrawnText{ x: 6, y: 0, data: " " }, DrawnText{ x: 7, y: 0, data: "is" },
@@ -226,7 +225,6 @@ fn test_buffer_view_draws_1_line_as_single_segment_that_that_elapses_max_width()
 		min_x, false, .normal, BufferCursor{}
 	)
 
-	// TODO(tauraamui) [14/04/2025]: need to assert against style draws as well
 	assert set_bg_color == [draw.Color{ 53, 53, 53 }, draw.Color{ 53, 53, 53 }]
 	assert drawn_rect == [
 		DrawnRect{ x: 2, y: 0, width: 19, height: 1 }
@@ -289,7 +287,6 @@ fn test_buffer_view_draws_1_line_as_multiple_segments_highlighted_as_expected() 
 		min_x, false, .normal, BufferCursor{}
 	)
 
-	// TODO(tauraamui) [14/04/2025]: need to assert against style draws as well
 	assert set_bg_color == [draw.Color{ 53, 53, 53 }, draw.Color{ 53, 53, 53 }]
 	assert drawn_rect == [
 		DrawnRect{ x: 2, y: 0, width: 39, height: 1 }
@@ -363,7 +360,6 @@ fn test_buffer_view_draws_1_line_as_single_segment_single_emoji() {
 		min_x, false, .normal, BufferCursor{}
 	)
 
-	// TODO(tauraamui) [14/04/2025]: need to assert against style draws as well
 	assert set_bg_color == [draw.Color{ 53, 53, 53 }, draw.Color{ 53, 53, 53 }]
 	assert drawn_rect == [
 		DrawnRect{ x: 2, y: 0, width: 19, height: 1 }
@@ -427,7 +423,6 @@ fn test_buffer_view_draws_lines_10_to_max_height() {
 		min_x, false, .normal, BufferCursor{ pos: CursorPos{ y: 12 } }
 	)
 
-	// TODO(tauraamui) [14/04/2025]: need to assert against style draws as well
 	assert set_bg_color == [draw.Color{ 53, 53, 53 }, draw.Color{ 53, 53, 53 }]
 	assert drawn_rect == [
 		DrawnRect{ x: 3, y: 2, width: 98, height: 1 }
@@ -742,7 +737,6 @@ fn test_buffer_view_draws_lines_10_to_max_height_relative_line_numbers_enabled()
 		min_x, true, .normal, BufferCursor{ pos: CursorPos{ y: 15 } }
 	) // toggle relative line numbers on
 
-	// TODO(tauraamui) [14/04/2025]: need to assert against style draws as well
 	assert set_bg_color == [draw.Color{ 53, 53, 53 }, draw.Color{ 53, 53, 53 }]
 	assert drawn_rect == [
 		DrawnRect{ x: 3, y: 5, width: 98, height: 1 }
@@ -1057,7 +1051,6 @@ fn test_buffer_view_draws_lines_10_to_max_height_relative_line_numbers_enabled_c
 		min_x, true, .normal, BufferCursor{ pos: CursorPos{ y: 15 } }
 	) // toggle relative line numbers on
 
-	// TODO(tauraamui) [14/04/2025]: need to assert against style draws as well
 	assert set_bg_color == [draw.Color{ 53, 53, 53 }, draw.Color{ 53, 53, 53 }]
 	assert drawn_rect == [
 		DrawnRect{ x: 3, y: 5, width: 98, height: 1 }
@@ -1308,7 +1301,6 @@ fn test_buffer_view_draws_lines_0_to_max_height_min_x_0_max_width_14() {
 
 	buf_view.draw(mut mock_ctx, x, y, width, height, from_line_num, min_x, false, .normal, BufferCursor{})
 
-	// TODO(tauraamui) [14/04/2025]: need to assert against style draws as well
 	assert set_bg_color == [draw.Color{ 53, 53, 53 }, draw.Color{ 53, 53, 53 }]
 	assert drawn_rect == [
 		DrawnRect{ x: 2, y: 0, width: 13, height: 1 }
@@ -1410,7 +1402,6 @@ fn test_buffer_view_draws_lines_0_to_max_height_min_x_4_max_width_56() {
 
 	buf_view.draw(mut mock_ctx, x, y, width, height, from_line_num, min_x, false, .normal, BufferCursor{})
 
-	// TODO(tauraamui) [14/04/2025]: need to assert against style draws as well
 	assert set_bg_color == [draw.Color{ 53, 53, 53 }, draw.Color{ 53, 53, 53 }]
 	assert drawn_rect == [
 		DrawnRect{ x: 2, y: 0, width: 55, height: 1 }
@@ -1534,7 +1525,6 @@ fn test_buffer_view_draws_lines_0_to_max_height_min_x_21_max_width_56() {
 
 	buf_view.draw(mut mock_ctx, x, y, width, height, from_line_num, min_x, false, .normal, BufferCursor{})
 
-	// TODO(tauraamui) [14/04/2025]: need to assert against style draws as well
 	assert set_bg_color == [draw.Color{ 53, 53, 53 }, draw.Color{ 53, 53, 53 }]
 	assert drawn_rect == [
 		DrawnRect{ x: 2, y: 0, width: 55, height: 1 }
@@ -1619,7 +1609,6 @@ fn test_buffer_view_draws_lines_0_to_max_height_min_x_21_max_width_6() {
 
 	buf_view.draw(mut mock_ctx, x, y, width, height, from_line_num, min_x, false, .normal, BufferCursor{})
 
-	// TODO(tauraamui) [14/04/2025]: need to assert against style draws as well
 	assert set_bg_color == [draw.Color{ 53, 53, 53 }, draw.Color{ 53, 53, 53 }]
 	assert drawn_rect == [
 		DrawnRect{ x: 2, y: 0, width: 11, height: 1 }

--- a/src/lib/ui/buffer_view_test.v
+++ b/src/lib/ui/buffer_view_test.v
@@ -910,21 +910,21 @@ fn test_buffer_view_draws_lines_0_to_max_height_min_x_0_max_width_14() {
 	// this is the line at the side being rendered
 	assert set_fg_color[8] == line_num_fg_color
 	assert syntax.color_to_type(set_fg_color[9])? == .number
-	assert syntax.color_to_type(set_fg_color[10])? == .identifier
+	assert syntax.color_to_type(set_fg_color[10])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[11])? == .identifier
-	assert syntax.color_to_type(set_fg_color[12])? == .identifier
+	assert syntax.color_to_type(set_fg_color[12])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[13])? == .identifier
-	assert syntax.color_to_type(set_fg_color[14])? == .identifier
+	assert syntax.color_to_type(set_fg_color[14])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[15])? == .identifier
 
 	// this is the line at the side being rendered
 	assert set_fg_color[16] == line_num_fg_color
 	assert syntax.color_to_type(set_fg_color[17])? == .number
-	assert syntax.color_to_type(set_fg_color[18])? == .identifier
+	assert syntax.color_to_type(set_fg_color[18])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[19])? == .identifier
-	assert syntax.color_to_type(set_fg_color[20])? == .identifier
+	assert syntax.color_to_type(set_fg_color[20])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[21])? == .identifier
-	assert syntax.color_to_type(set_fg_color[22])? == .identifier
+	assert syntax.color_to_type(set_fg_color[22])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[23])? == .identifier
 
 	line_one_expected_drawn_data := [

--- a/src/lib/ui/buffer_view_test.v
+++ b/src/lib/ui/buffer_view_test.v
@@ -480,6 +480,34 @@ fn test_buffer_view_draws_lines_10_to_max_height() {
 	assert syntax.color_to_type(set_fg_color[40])? == .whitespace
 	assert syntax.color_to_type(set_fg_color[41])? == .identifier
 
+	assert set_fg_color[42] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[43])? == .identifier
+	assert syntax.color_to_type(set_fg_color[44])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[45])? == .identifier
+	assert syntax.color_to_type(set_fg_color[46])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[47])? == .identifier
+	assert syntax.color_to_type(set_fg_color[48])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[49])? == .number
+	assert syntax.color_to_type(set_fg_color[50])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[51])? == .identifier
+	assert syntax.color_to_type(set_fg_color[52])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[53])? == .identifier
+	assert syntax.color_to_type(set_fg_color[54])? == .whitespace
+
+	assert set_fg_color[55] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[56])? == .identifier
+	assert syntax.color_to_type(set_fg_color[57])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[58])? == .identifier
+	assert syntax.color_to_type(set_fg_color[59])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[60])? == .identifier
+	assert syntax.color_to_type(set_fg_color[61])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[62])? == .number
+	assert syntax.color_to_type(set_fg_color[63])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[64])? == .identifier
+	assert syntax.color_to_type(set_fg_color[65])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[66])? == .identifier
+	assert syntax.color_to_type(set_fg_color[67])? == .whitespace
+
 	line_one_expected_drawn_data := [
 		DrawnText{ x: 0, y: 0, data: "11" }, DrawnText{ x: 3, y: 0, data: "This" },
 		DrawnText{ x: 7, y: 0, data: " " }, DrawnText{ x: 8, y: 0, data: "is" },

--- a/src/lib/ui/buffer_view_test.v
+++ b/src/lib/ui/buffer_view_test.v
@@ -1500,6 +1500,9 @@ fn test_buffer_view_draws_lines_0_to_max_height_min_x_21_max_width_56() {
 	mut set_fg_color := []draw.Color{}
 	mut set_fg_color_ref := &set_fg_color
 
+	mut set_bg_color := []draw.Color{}
+	mut set_bg_color_ref := &set_bg_color
+
 	mut drawn_rect := []DrawnRect{}
 	mut drawn_rect_ref := &drawn_rect
 
@@ -1512,6 +1515,9 @@ fn test_buffer_view_draws_lines_0_to_max_height_min_x_21_max_width_56() {
 		}
 		on_set_fg_color_cb: fn [mut set_fg_color_ref] (c draw.Color) {
 			set_fg_color_ref << c
+		}
+		on_set_bg_color_cb: fn [mut set_bg_color_ref] (c draw.Color) {
+			set_bg_color_ref << c
 		}
 	}
 
@@ -1529,12 +1535,29 @@ fn test_buffer_view_draws_lines_0_to_max_height_min_x_21_max_width_56() {
 	buf_view.draw(mut mock_ctx, x, y, width, height, from_line_num, min_x, false, .normal, BufferCursor{})
 
 	// TODO(tauraamui) [14/04/2025]: need to assert against style draws as well
+	assert set_bg_color == [draw.Color{ 53, 53, 53 }, draw.Color{ 53, 53, 53 }]
 	assert drawn_rect == [
 		DrawnRect{ x: 2, y: 0, width: 55, height: 1 }
 	]
 
 	assert drawn_text.len == 12
 	assert set_fg_color.len == 12
+
+	// this is the line at the side being rendered
+	assert set_fg_color[0] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[1])? == .identifier
+	assert syntax.color_to_type(set_fg_color[2])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[3])? == .identifier
+
+	assert set_fg_color[4] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[5])? == .identifier
+	assert syntax.color_to_type(set_fg_color[6])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[7])? == .identifier
+
+	assert set_fg_color[8] == line_num_fg_color
+	assert syntax.color_to_type(set_fg_color[9])? == .identifier
+	assert syntax.color_to_type(set_fg_color[10])? == .whitespace
+	assert syntax.color_to_type(set_fg_color[11])? == .identifier
 
 	line_one_expected_drawn_data := [
 		DrawnText{ x: 0, y: 0, data: "1" }, DT{ x: 2, y: 0, data: "he" },

--- a/src/view.v
+++ b/src/view.v
@@ -540,13 +540,15 @@ fn (mut view View) draw_cursor_pointer(mut ctx draw.Contextable) {
 fn (mut view View) draw_x(mut ctx draw.Contextable) {
 	view.offset_x_and_width_by_len_of_longest_line_number_str(ctx.window_width(), ctx.window_height())
 
+	selection_highlight_color := view.config.selection_highlight_color()
 	view.buf_view.draw(
 		mut ctx, 0, 0,
 		ctx.window_width(), ctx.window_height() - 2,
 		view.from, 0,
 		view.config.relative_line_numbers,
 		view.leader_state.mode,
-		view.cursor
+		view.cursor,
+		draw.Color{ r: selection_highlight_color.r, g: selection_highlight_color.g, b: selection_highlight_color.b }
 	)
 
 	ui.draw_status_line(


### PR DESCRIPTION
Addresses nothing in the issues list directly. But this branch is getting too big regardless. We do at least now have a well defined mechanism for inferring whether a token to be rendered does lie within its lines selection span and by how much.