### PR TITLE
fix: adds git hash generation before tests

### DIFF
--- a/make.vsh
+++ b/make.vsh
@@ -20,8 +20,8 @@ context.task(name: "run-gui", depends: ["_generate-git-hash"], run: |self| syste
 context.task(name: "compile-make", run: |self| system("v -prod -skip-running make.vsh"))
 
 // TEST TASKS
-context.task(name: "test", run: |self| exit(system("v -g test ./src")))
-context.task(name: "verbose-test", run: |self| exit(system("v -g -stats test ./src")))
+context.task(name: "test", depends: ["_generate-git-hash"], run: |self| exit(system("v -g test ./src")))
+context.task(name: "verbose-test", depends: ["_generate-git-hash"], run: |self| exit(system("v -g -stats test ./src")))
 
 // EXPERIMENTS
 context.task(


### PR DESCRIPTION
Not sure if this is all you wanted out of this issue. But screenshot shows it failing first time on a fresh clone, then I added the dependency, and then they generate the hash and pass. (I only used helix because lilly wasnt built, promise!)

<img width="1172" height="995" alt="image" src="https://github.com/user-attachments/assets/01aaeee6-7a08-4b84-ad45-479267457969" />

addresses #486