### PR TITLE
test: stop list content comp randomly failing out of order

### DIFF
--- a/src/lilly_test.v
+++ b/src/lilly_test.v
@@ -135,7 +135,7 @@ fn test_lilly_resolve_matches_across_all_open_file_buffers_only_loaded_file_has_
 	assert lilly.file_buffers.len == 1
 	assert lilly.buffer_views.len == 1
 
-	assert lilly.resolve_todo_comments_matches() == [
+	assert lilly.resolve_todo_comments_matches().sorted(a.pos.x < b.pos.x) == [ // make the test output deterministic, prevent random out of order assert failures
 		buffer.Match{
 			contents: "TODO(tauraamui) [26/02/2025]: become a real boy, I mean file!"
 			file_path: "loaded-test-file.txt", pos: buffer.Pos{ x: 3, y: 0 }


### PR DESCRIPTION
Very occasionally a perfectly healthy test suite run will fail as the order of which the list this test is comparing against is not 100% guaranteed. By adding this copy + sort we're making the actual list order consistent.