### PR TITLE
chore: render leader key bind on splash

### DIFF
--- a/splash_screen.v
+++ b/splash_screen.v
@@ -326,6 +326,10 @@ fn render_keybinds_list(mut ctx tea.Context,
 	offset_from_id := ctx.push_offset(tea.Offset{ y: 1 })
 	defer { ctx.clear_offsets_from(offset_from_id) }
 
+	leader_key_label := 'leader = ;'
+	ctx.draw_text(-(tea.visible_len(leader_key_label) / 2), 0, leader_key_label)
+	ctx.push_offset(tea.Offset{ y: 1 })
+
 	for l in basic_command_help {
 		ctx.push_offset(tea.Offset{ y: 1 })
 		ctx.push_offset(tea.Offset{ x: -(tea.visible_len(l) / 2) })


### PR DESCRIPTION
Will make this dynamic when its possible to configure it to something else

<img width="336" height="211" alt="image" src="https://github.com/user-attachments/assets/1234f264-b0eb-4e4d-9b3f-2915555c53e0" />
